### PR TITLE
Ignore WaitingOnDeps for agent calculation

### DIFF
--- a/engine/autoscaler.go
+++ b/engine/autoscaler.go
@@ -33,7 +33,7 @@ func (a *Autoscaler) getQueueInfo(_ context.Context) (freeTasks, runningTasks, p
 		return -1, -1, -1, fmt.Errorf("client.QueueInfo: %w", err)
 	}
 
-	return info.Stats.Workers, info.Stats.Running, info.Stats.Pending + info.Stats.WaitingOnDeps, nil
+	return info.Stats.Workers, info.Stats.Running, info.Stats.Pending, nil
 }
 
 func (a *Autoscaler) loadAgents(_ context.Context) error {


### PR DESCRIPTION
Sum `WaitingOnDeps` to `Pending` IMO results in wrong agent calculation and will create too many agents. 

Pipelines waiting for dependencies to terminate do not require resource reservation because the dependency already frees capacity after it terminates.