### PR TITLE
Use keys.openpgp.org as default keyserver

### DIFF
--- a/engine/const.go
+++ b/engine/const.go
@@ -26,6 +26,7 @@ apt:
     docker.list:
       source: deb https://download.docker.com/linux/ubuntu $RELEASE stable
       keyid: 0EBFCD88
+      keyserver: keys.openpgp.org
 
 packages:
   - docker-ce


### PR DESCRIPTION
Currently, the default key server `keyserver.ubuntu.com` is down and prevents agent bootstrapping. As this happened multiple times now over the last months, I think this key server is too flaky, and I would propose to use keys.openpgp.org instead.

I'm also ok to just override the default userdata in my deployments if someone prefers this way. 