### PR TITLE
Use docker gpg key from download.docker.com

### DIFF
--- a/engine/const.go
+++ b/engine/const.go
@@ -24,8 +24,9 @@ system_info:
 apt:
   sources:
     docker.list:
-      source: deb https://download.docker.com/linux/ubuntu $RELEASE stable
-      keyid: 0EBFCD88
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+      keyserver: https://download.docker.com/linux/ubuntu/gpg
+      source: deb [signed-by=$KEY_FILE] https://download.docker.com/linux/ubuntu $RELEASE stable
 
 packages:
   - docker-ce


### PR DESCRIPTION
This works and is using the official key from download.docker.com directly. 

Usage of `[signed-by=$KEY_FILE]` is intended, otherwise cloud-init will install the key into `trusted.gpg.d/`, where apt will treat it as globally trusted. 

Ref: https://cloudinit.readthedocs.io/en/latest/reference/examples.html#additional-apt-configuration-and-repositories