### PR TITLE
Add agent idle timeout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/",
+      "program": "${workspaceFolder}/cmd/woodpecker-autoscaler",
       "envFile": "${workspaceFolder}/.env"
     }
   ]

--- a/cmd/woodpecker-autoscaler/flags.go
+++ b/cmd/woodpecker-autoscaler/flags.go
@@ -44,6 +44,12 @@ var flags = []cli.Flag{
 		Usage:   "time an agent is allowed to be inactive before it can be terminated as duration string like 2h45m (https://pkg.go.dev/time#ParseDuration)",
 		EnvVars: []string{"WOODPECKER_AGENT_INACTIVITY_TIMEOUT", "WOODPECKER_AGENT_ALLOWED_STARTUP_TIME"},
 	},
+	&cli.StringFlag{
+		Name:    "agent-idle-timeout",
+		Value:   "10m",
+		Usage:   "time an agent is allowed to be idle before it can be terminated as duration string like 2h45m (https://pkg.go.dev/time#ParseDuration)",
+		EnvVars: []string{"WOODPECKER_AGENT_IDLE_TIMEOUT"},
+	},
 	&cli.IntFlag{
 		Name:    "workflows-per-agent",
 		Value:   2,

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -73,6 +73,11 @@ func run(ctx *cli.Context) error {
 		return fmt.Errorf("can't parse agent-inactivity-timeout: %w", err)
 	}
 
+	config.AgentIdleTimeout, err = time.ParseDuration(ctx.String("agent-idle-timeout"))
+	if err != nil {
+		return fmt.Errorf("can't parse agent-idle-timeout: %w", err)
+	}
+
 	reconciliationInterval, err := time.ParseDuration(ctx.String("reconciliation-interval"))
 	if err != nil {
 		return fmt.Errorf("can't parse reconciliation-interval: %w", err)

--- a/config/config.go
+++ b/config/config.go
@@ -12,5 +12,6 @@ type Config struct {
 	GRPCAddress            string
 	GRPCSecure             bool
 	AgentInactivityTimeout time.Duration
+	AgentIdleTimeout       time.Duration
 	FilterLabels           string
 }

--- a/engine/autoscaler.go
+++ b/engine/autoscaler.go
@@ -110,7 +110,17 @@ func (a *Autoscaler) isAgentIdle(agent *woodpecker.Agent) (bool, error) {
 		return false, fmt.Errorf("client.AgentTasksList: %w", err)
 	}
 
-	return len(tasks) == 0, nil
+	// agent still has tasks => not idle
+	if len(tasks) > 0 {
+		return false, nil
+	}
+
+	// agent has done work recently => not idle
+	if time.Since(time.Unix(agent.LastWork, 0)) < a.config.AgentIdleTimeout {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (a *Autoscaler) removeAgent(ctx context.Context, agent *woodpecker.Agent, reason string) error {

--- a/engine/autoscaler_test.go
+++ b/engine/autoscaler_test.go
@@ -308,6 +308,72 @@ func Test_cleanupStaleAgents(t *testing.T) {
 	})
 }
 
+func Test_isAgentIdle(t *testing.T) {
+	t.Run("should return false if agent has tasks", func(t *testing.T) {
+		client := mocks_server.NewMockClient(t)
+		autoscaler := Autoscaler{
+			client: client,
+			config: &config.Config{
+				AgentIdleTimeout: time.Minute * 15,
+			},
+		}
+
+		client.On("AgentTasksList", int64(1)).Return([]*woodpecker.Task{
+			{ID: "1"},
+		}, nil)
+
+		idle, err := autoscaler.isAgentIdle(&woodpecker.Agent{
+			ID:         1,
+			Name:       "pool-1-agent-1",
+			NoSchedule: false,
+		})
+		assert.NoError(t, err)
+		assert.False(t, idle)
+	})
+
+	t.Run("should return false if agent has done work recently", func(t *testing.T) {
+		client := mocks_server.NewMockClient(t)
+		autoscaler := Autoscaler{
+			client: client,
+			config: &config.Config{
+				AgentIdleTimeout: time.Minute * 15,
+			},
+		}
+
+		client.On("AgentTasksList", int64(1)).Return(nil, nil)
+
+		idle, err := autoscaler.isAgentIdle(&woodpecker.Agent{
+			ID:         1,
+			Name:       "pool-1-agent-1",
+			NoSchedule: false,
+			LastWork:   time.Now().Add(-time.Minute * 10).Unix(),
+		})
+		assert.NoError(t, err)
+		assert.False(t, idle)
+	})
+
+	t.Run("should return true if agent is idle", func(t *testing.T) {
+		client := mocks_server.NewMockClient(t)
+		autoscaler := Autoscaler{
+			client: client,
+			config: &config.Config{
+				AgentIdleTimeout: time.Minute * 15,
+			},
+		}
+
+		client.On("AgentTasksList", int64(1)).Return(nil, nil) // no tasks
+
+		idle, err := autoscaler.isAgentIdle(&woodpecker.Agent{
+			ID:         1,
+			Name:       "pool-1-agent-1",
+			NoSchedule: false,
+			LastWork:   time.Now().Add(-time.Minute * 20).Unix(), // last work 20 minutes ago
+		})
+		assert.NoError(t, err)
+		assert.True(t, idle)
+	})
+}
+
 func Test_removeDrainedAgents(t *testing.T) {
 	t.Run("should remove agent", func(t *testing.T) {
 		ctx := context.Background()
@@ -321,6 +387,9 @@ func Test_removeDrainedAgents(t *testing.T) {
 			},
 			provider: provider,
 			client:   client,
+			config: &config.Config{
+				AgentIdleTimeout: time.Minute * 15,
+			},
 		}
 
 		client.On("AgentTasksList", int64(2)).Return(nil, nil)

--- a/engine/autoscaler_test.go
+++ b/engine/autoscaler_test.go
@@ -189,7 +189,6 @@ func Test_getPoolAgents(t *testing.T) {
 }
 
 func Test_cleanupDanglingAgents(t *testing.T) {
-
 	t.Run("should remove agent that is only present on woodpecker (not provider)", func(t *testing.T) {
 		ctx := context.Background()
 		client := mocks_server.NewMockClient(t)
@@ -232,7 +231,6 @@ func Test_cleanupDanglingAgents(t *testing.T) {
 }
 
 func Test_cleanupStaleAgents(t *testing.T) {
-
 	t.Run("should remove agent that never connected (last contact = 0) in over 15 minutes", func(t *testing.T) {
 		ctx := context.Background()
 		client := mocks_server.NewMockClient(t)

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2
-	go.woodpecker-ci.org/woodpecker/v2 v2.6.0
+	go.woodpecker-ci.org/woodpecker/v2 v2.6.1-0.20240702091207-e5f3e67bf282
 	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/net v0.26.0
 	golang.org/x/oauth2 v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBi
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.woodpecker-ci.org/woodpecker/v2 v2.6.0 h1:GnfiYLLkKdrmvCmLrs+JQyw8iJv8ts6ux0lou37CdP4=
 go.woodpecker-ci.org/woodpecker/v2 v2.6.0/go.mod h1:5ncjE/WmU7BkcDfDPE7tajf4+zH0KELxLqpVgT94w6c=
+go.woodpecker-ci.org/woodpecker/v2 v2.6.1-0.20240702091207-e5f3e67bf282 h1:hBmt1mCmkTBLZpZCv+jlcnvmcESUCKiIl8dLZbZXEu4=
+go.woodpecker-ci.org/woodpecker/v2 v2.6.1-0.20240702091207-e5f3e67bf282/go.mod h1:VZ3FHAZY4PcLGJCpsF3ojTGvuCUut5O1LVvBg+HTpUA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=


### PR DESCRIPTION
closes #73

Allows to set an idle time an agent has before its being drained.

Not sure how we could implement the "deletion window" for hetzner best. So an agent is only deleted / drained if it is just about the next full hour (might however be possible to implement this in a next step anyways).