### PR TITLE
docs: add AWS as supported cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The agents will use `WOODEPCKER_GRPC_ADDR` and a token automatically generated b
 
 - [ ] Add support for multiple providers
   - [x] Hetzner Cloud
-  - [ ] Amazon AWS
+  - [x] Amazon AWS
   - [ ] Google Cloud
   - [ ] Azure
   - [ ] Digital Ocean


### PR DESCRIPTION
The support was added in https://github.com/woodpecker-ci/autoscaler/releases/tag/0.3.0