### PR TITLE
Bump golangci-lint to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,70 +1,85 @@
-linters-settings:
-  gofmt:
-    simplify: true
-    rewrite-rules:
-      - pattern: interface{}
-        replacement: any
-  misspell:
-    locale: US
-  gofumpt:
-    extra-rules: true
-  forbidigo:
-    forbid:
-      - context\.WithCancel$
-      - ^print.*$
-      - panic
-      - ^log.Fatal().*$
-  gci:
-    custom-order: true
-    sections:
-      - standard
-      - default
-      - prefix(go.woodpecker-ci.org)
-
+version: '2'
 linters:
-  disable-all: true
+  default: none
   enable:
-    - bidichk
-    - errcheck
-    - gofmt
-    - gosimple
-    - govet
-    - ineffassign
-    - misspell
-    - revive
-    - staticcheck
-    - typecheck
-    - unused
-    - gofumpt
-    - errorlint
-    - forbidigo
-    - zerologlint
     - asciicheck
+    - bidichk
     - bodyclose
+    - contextcheck
     - dogsled
     - durationcheck
+    - errcheck
     - errchkjson
+    - errorlint
+    - forbidigo
+    - forcetypeassert
     - gochecknoinits
+    - gocritic
     - goheader
     - gomoddirectives
     - gomodguard
     - goprintffuncname
+    - govet
     - importas
+    - ineffassign
     - makezero
+    - misspell
+    - mnd
+    - nolintlint
+    - revive
     - rowserrcheck
     - sqlclosecheck
-    - tenv
+    - staticcheck
     - unconvert
     - unparam
+    - unused
     - wastedassign
     - whitespace
-    - gocritic
-    - nolintlint
-    - stylecheck
-    - contextcheck
-    - forcetypeassert
+    - zerologlint
+  settings:
+    forbidigo:
+      forbid:
+        - pattern: context\.WithCancel$
+        - pattern: ^print.*$
+        - pattern: panic
+        - pattern: ^log.Fatal().*$
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
     - gci
-    - mnd
-
+    - gofmt
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(go.woodpecker-ci.org)
+      custom-order: true
+    gofmt:
+      simplify: true
+      rewrite-rules:
+        - pattern: interface{}
+          replacement: any
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 run:
-  timeout: 5m
+  timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ clean: ## Clean build artifacts
 
 install-tools: ## Install development tools
 	@hash golangci-lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
 	fi ; \
 	hash lint > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		go install github.com/rs/zerolog/cmd/lint@latest; \
@@ -84,7 +84,7 @@ install-tools: ## Install development tools
 .PHONY: lint
 lint: install-tools ## Lint code
 	@echo "Running golangci-lint"
-	golangci-lint run --timeout 10m
+	golangci-lint run
 	@echo "Running zerolog linter"
 	lint go.woodpecker-ci.org/autoscaler/cmd/woodpecker-autoscaler
 


### PR DESCRIPTION
Config file transformed with `golangci-lint migrate`.