### PR TITLE
feat: add Woodpecker to Hetzner Cloud client user agent

### DIFF
--- a/providers/hetznercloud/hcapi/api.go
+++ b/providers/hetznercloud/hcapi/api.go
@@ -67,7 +67,10 @@ type firewallClient struct {
 
 func NewClient(opts ...hcloud.ClientOption) Client {
 	return &client{
-		client: hcloud.NewClient(opts...),
+		client: hcloud.NewClient(append(
+			opts,
+			hcloud.WithApplication("woodpecker-autoscaler", ""),
+		)...),
 	}
 }
 


### PR DESCRIPTION
Add Woodpecker details to the Hetzner Cloud client user-agent.

Helps us identify and troubleshoot issues with users running Woodpecker on Hetzner Cloud.