### PR TITLE
feat: add DigitalOcean provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The agents will use `WOODPECKER_GRPC_ADDR` and a token automatically generated b
   - [x] Amazon AWS
   - [ ] Google Cloud
   - [ ] Azure
-  - [ ] Digital Ocean
+  - [x] Digital Ocean
   - [x] Linode (temp disabled until the [security issue](https://github.com/woodpecker-ci/autoscaler/issues/91) was addressed)
   - [ ] Oracle Cloud
   - [ ] Equinix Metal

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -15,6 +15,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/config"
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/digitalocean"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
@@ -26,6 +27,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	switch cmd.String("provider") {
 	case "aws":
 		return aws.New(ctx, cmd, config)
+	case "digitalocean":
+		return digitalocean.New(ctx, cmd, config)
 	case "hetznercloud":
 		return hetznercloud.New(ctx, cmd, config)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
@@ -135,12 +138,13 @@ func main() {
 		Action: run,
 	}
 
+	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, digitalocean.ProviderFlags...)
 	app.Flags = append(app.Flags, hetznercloud.ProviderFlags...)
-	app.Flags = append(app.Flags, scaleway.ProviderFlags...)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
 	// Enable it again when the issue is fixed.
 	// app.Flags = append(app.Flags, linode.ProviderFlags...)
-	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, scaleway.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.285.0
+	github.com/digitalocean/godo v1.131.1
 	github.com/docker/go-units v0.5.0
 	github.com/hetznercloud/hcloud-go/v2 v2.36.0
 	github.com/joho/godotenv v1.5.1

--- a/providers/digitalocean/flags.go
+++ b/providers/digitalocean/flags.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "DigitalOcean"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "digitalocean-api-token",
+		Usage: "DigitalOcean API token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-region",
+		Value:    "nyc1",
+		Usage:    "DigitalOcean region (e.g., nyc1, sfo1, ams3)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-size",
+		Value:    "s-1vcpu-1gb",
+		Usage:    "DigitalOcean droplet size (e.g., s-1vcpu-1gb, s-2vcpu-2gb)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SIZE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-image",
+		Value:    "ubuntu-22-04-x64",
+		Usage:    "DigitalOcean OS image slug (e.g., ubuntu-22-04-x64, ubuntu-24-04-x64)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IMAGE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-ssh-key",
+		Usage:    "DigitalOcean SSH key fingerprint or ID",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SSH_KEY"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-tags",
+		Usage:    "DigitalOcean droplet tags",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_TAGS"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-vpc-uuid",
+		Usage:    "DigitalOcean VPC UUID (optional)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_VPC_UUID"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-ipv6",
+		Value:    false,
+		Usage:    "Enable IPv6 for droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IPV6"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-monitoring",
+		Value:    true,
+		Usage:    "Enable monitoring for droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_MONITORING"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-firewall-id",
+		Usage:    "DigitalOcean firewall ID to apply to droplets (optional)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_FIREWALL_ID"),
+		Category: category,
+	},
+}

--- a/providers/digitalocean/provider.go
+++ b/providers/digitalocean/provider.go
@@ -1,0 +1,238 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/digitalocean/godo"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var (
+	ErrSSHKeyNotFound = errors.New("SSH key not found")
+)
+
+type Provider struct {
+	name             string
+	region           string
+	size             string
+	image            string
+	sshKey           string
+	tags             []string
+	vpcUUID          string
+	ipv6             bool
+	monitoring       bool
+	firewallID       string
+	config           *config.Config
+	userDataTemplate *template.Template
+	client           *godo.Client
+}
+
+func New(ctx context.Context, c *cli.Command, config *config.Config) (engine.Provider, error) {
+	p := &Provider{
+		name:       "digitalocean",
+		region:     c.String("digitalocean-region"),
+		size:       c.String("digitalocean-size"),
+		image:      c.String("digitalocean-image"),
+		sshKey:     c.String("digitalocean-ssh-key"),
+		tags:       c.StringSlice("digitalocean-tags"),
+		vpcUUID:    c.String("digitalocean-vpc-uuid"),
+		ipv6:       c.Bool("digitalocean-ipv6"),
+		monitoring: c.Bool("digitalocean-monitoring"),
+		firewallID: c.String("digitalocean-firewall-id"),
+		config:     config,
+	}
+
+	p.client = godo.NewFromToken(c.String("digitalocean-api-token"))
+
+	err := p.setupKeypair(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: setupKeypair: %w", p.name, err)
+	}
+
+	return p, nil
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := engine.RenderUserDataTemplate(p.config, agent, p.userDataTemplate)
+	if err != nil {
+		return fmt.Errorf("%s: engine.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	// Prepare SSH keys
+	sshKeys := []godo.DropletCreateSSHKey{}
+	if p.sshKey != "" {
+		// Try to parse as ID first
+		if id, err := strconv.Atoi(p.sshKey); err == nil {
+			sshKeys = append(sshKeys, godo.DropletCreateSSHKey{ID: id})
+		} else {
+			// Treat as fingerprint
+			sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: p.sshKey})
+		}
+	}
+
+	// Build tags list, always include woodpecker-agent tag for identification
+	tags := append([]string{"woodpecker-agent"}, p.tags...)
+
+	createRequest := &godo.DropletCreateRequest{
+		Name:       agent.Name,
+		Region:     p.region,
+		Size:       p.size,
+		Image:      godo.DropletCreateImage{Slug: p.image},
+		SSHKeys:    sshKeys,
+		Tags:       tags,
+		IPv6:       p.ipv6,
+		Monitoring: p.monitoring,
+		UserData:   userData,
+	}
+
+	// Set VPC if specified
+	if p.vpcUUID != "" {
+		createRequest.VPCUUID = p.vpcUUID
+	}
+
+	droplet, _, err := p.client.Droplets.Create(ctx, createRequest)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Create: %w", p.name, err)
+	}
+
+	log.Info().Str("agent", agent.Name).Int("droplet_id", droplet.ID).Msg("droplet created")
+
+	// Apply firewall if specified
+	if p.firewallID != "" {
+		_, err = p.client.Firewalls.AddDroplets(ctx, p.firewallID, droplet.ID)
+		if err != nil {
+			log.Warn().Err(err).Str("firewall_id", p.firewallID).Msg("failed to add droplet to firewall")
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) getDroplet(ctx context.Context, agent *woodpecker.Agent) (*godo.Droplet, error) {
+	// List droplets with woodpecker-agent tag
+	opt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	droplets, _, err := p.client.Droplets.ListByTag(ctx, "woodpecker-agent", opt)
+	if err != nil {
+		return nil, fmt.Errorf("%s: Droplets.ListByTag: %w", p.name, err)
+	}
+
+	for _, droplet := range droplets {
+		if droplet.Name == agent.Name {
+			return &droplet, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	droplet, err := p.getDroplet(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("%s: getDroplet: %w", p.name, err)
+	}
+
+	if droplet == nil {
+		log.Debug().Str("agent", agent.Name).Msg("droplet not found, nothing to remove")
+		return nil
+	}
+
+	_, err = p.client.Droplets.Delete(ctx, droplet.ID)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Delete: %w", p.name, err)
+	}
+
+	log.Info().Str("agent", agent.Name).Int("droplet_id", droplet.ID).Msg("droplet deleted")
+
+	return nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	var names []string
+
+	opt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	// List all droplets with woodpecker-agent tag
+	droplets, _, err := p.client.Droplets.ListByTag(ctx, "woodpecker-agent", opt)
+	if err != nil {
+		return nil, fmt.Errorf("%s: Droplets.ListByTag: %w", p.name, err)
+	}
+
+	for _, droplet := range droplets {
+		// Only include droplets that match the agent naming pattern
+		if strings.Contains(droplet.Name, "agent") {
+			names = append(names, droplet.Name)
+		}
+	}
+
+	return names, nil
+}
+
+func (p *Provider) setupKeypair(ctx context.Context) error {
+	// If SSH key is already configured via flag, use it
+	if p.sshKey != "" {
+		return nil
+	}
+
+	// List all SSH keys
+	opt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	keys, _, err := p.client.Keys.List(ctx, opt)
+	if err != nil {
+		return fmt.Errorf("Keys.List: %w", err)
+	}
+
+	// Try to find a key with common names
+	for _, name := range []string{"woodpecker", "id_rsa_woodpecker", "id_ed25519"} {
+		for _, key := range keys {
+			if key.Name == name {
+				p.sshKey = key.Fingerprint
+				log.Info().Str("key", name).Msg("using SSH key")
+				return nil
+			}
+		}
+	}
+
+	// Use the first available key
+	if len(keys) > 0 {
+		p.sshKey = keys[0].Fingerprint
+		log.Info().Str("key", keys[0].Name).Msg("using first available SSH key")
+		return nil
+	}
+
+	log.Warn().Msg("no SSH key found, droplets will be created without SSH access")
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR adds DigitalOcean as a cloud provider for the autoscaler, addressing issue #103.

## Features

- **Create and manage DigitalOcean Droplets** as Woodpecker agents
- **Configurable options:**
  - Region (default: `nyc1`)
  - Droplet size (default: `s-1vcpu-1gb`)
  - OS image (default: `ubuntu-22-04-x64`)
  - SSH key (auto-detected or manually configured)
  - Tags for organization
  - VPC UUID (optional)
  - Firewall ID (optional)
  - IPv6 support
  - Monitoring support
- **Tag-based droplet identification** for reliable cleanup
- **Automatic SSH key detection** from account

## Environment Variables

| Variable | Description | Default |
|----------|-------------|--------|
| `WOODPECKER_DIGITALOCEAN_API_TOKEN` | DigitalOcean API token | (required) |
| `WOODPECKER_DIGITALOCEAN_REGION` | Region slug | `nyc1` |
| `WOODPECKER_DIGITALOCEAN_SIZE` | Droplet size | `s-1vcpu-1gb` |
| `WOODPECKER_DIGITALOCEAN_IMAGE` | OS image slug | `ubuntu-22-04-x64` |
| `WOODPECKER_DIGITALOCEAN_SSH_KEY` | SSH key fingerprint/ID | auto-detected |
| `WOODPECKER_DIGITALOCEAN_TAGS` | Droplet tags | |
| `WOODPECKER_DIGITALOCEAN_VPC_UUID` | VPC UUID | |
| `WOODPECKER_DIGITALOCEAN_IPV6` | Enable IPv6 | `false` |
| `WOODPECKER_DIGITALOCEAN_MONITORING` | Enable monitoring | `true` |
| `WOODPECKER_DIGITALOCEAN_FIREWALL_ID` | Firewall ID | |

## Example Usage

```yaml
services:
  woodpecker-autoscaler:
    image: woodpeckerci/autoscaler:next
    environment:
      - WOODPECKER_PROVIDER=digitalocean
      - WOODPECKER_DIGITALOCEAN_API_TOKEN=${DO_API_TOKEN}
      - WOODPECKER_DIGITALOCEAN_REGION=nyc3
      - WOODPECKER_DIGITALOCEAN_SIZE=s-2vcpu-2gb
```

## Checklist

- [x] Provider implementation following existing patterns (linode, vultr, etc.)
- [x] CLI flags for all configuration options
- [x] Integration with main.go
- [x] Updated README roadmap
- [x] Added godo dependency to go.mod

Closes #103