### PR TITLE
feat: add Oracle Cloud provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The agents will use `WOODPECKER_GRPC_ADDR` and a token automatically generated b
   - [ ] Azure
   - [ ] Digital Ocean
   - [x] Linode (temp disabled until the [security issue](https://github.com/woodpecker-ci/autoscaler/issues/91) was addressed)
-  - [ ] Oracle Cloud
+  - [x] Oracle Cloud
   - [ ] Equinix Metal
   - [x] Vultr
   - [x] Scaleway

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -16,6 +16,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
+	"go.woodpecker-ci.org/autoscaler/providers/oracle"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
 	"go.woodpecker-ci.org/autoscaler/server"
@@ -36,6 +37,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 		return vultr.New(ctx, cmd, config)
 	case "scaleway":
 		return scaleway.New(ctx, cmd, config)
+	case "oracle":
+		return oracle.New(ctx, cmd, config)
 	case "":
 		return nil, fmt.Errorf("please select a provider")
 	}
@@ -136,6 +139,7 @@ func main() {
 	}
 
 	app.Flags = append(app.Flags, hetznercloud.ProviderFlags...)
+	app.Flags = append(app.Flags, oracle.ProviderFlags...)
 	app.Flags = append(app.Flags, scaleway.ProviderFlags...)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
 	// Enable it again when the issue is fixed.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hetznercloud/hcloud-go/v2 v2.36.0
 	github.com/joho/godotenv v1.5.1
 	github.com/linode/linodego v1.64.0
+	github.com/oracle/oci-go-sdk/v65 v65.83.0
 	github.com/rs/zerolog v1.34.0
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.36
 	github.com/stretchr/testify v1.11.1

--- a/providers/oracle/flags.go
+++ b/providers/oracle/flags.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "Oracle Cloud"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "oracle-tenancy-ocid",
+		Usage: "Oracle Cloud tenancy OCID",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_ORACLE_TENANCY_OCID"),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:  "oracle-user-ocid",
+		Usage: "Oracle Cloud user OCID",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_ORACLE_USER_OCID"),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:  "oracle-fingerprint",
+		Usage: "Oracle Cloud API key fingerprint",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_ORACLE_FINGERPRINT"),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:  "oracle-private-key",
+		Usage: "Oracle Cloud API private key (PEM format)",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_ORACLE_PRIVATE_KEY"),
+			cli.File(os.Getenv("WOODPECKER_ORACLE_PRIVATE_KEY_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-region",
+		Value:    "us-ashburn-1",
+		Usage:    "Oracle Cloud region (e.g., us-ashburn-1, eu-frankfurt-1)",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-compartment-ocid",
+		Usage:    "Oracle Cloud compartment OCID for resources",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_COMPARTMENT_OCID"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-availability-domain",
+		Usage:    "Oracle Cloud availability domain (e.g., Uocm:PHX-AD-1)",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_AVAILABILITY_DOMAIN"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-subnet-ocid",
+		Usage:    "Oracle Cloud subnet OCID for instances",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_SUBNET_OCID"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-shape",
+		Value:    "VM.Standard.E4.Flex",
+		Usage:    "Oracle Cloud instance shape (e.g., VM.Standard.E4.Flex, VM.Standard.A1.Flex)",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_SHAPE"),
+		Category: category,
+	},
+	&cli.IntFlag{
+		Name:     "oracle-ocpus",
+		Value:    1,
+		Usage:    "Number of OCPUs for flexible shapes",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_OCPUS"),
+		Category: category,
+	},
+	&cli.IntFlag{
+		Name:     "oracle-memory-gb",
+		Value:    4,
+		Usage:    "Memory in GB for flexible shapes",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_MEMORY_GB"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-image-ocid",
+		Usage:    "Oracle Cloud image OCID (e.g., Oracle Linux or Ubuntu)",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_IMAGE_OCID"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "oracle-ssh-public-key",
+		Usage:    "SSH public key for instance access",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_SSH_PUBLIC_KEY"),
+		Category: category,
+	},
+	&cli.IntFlag{
+		Name:     "oracle-boot-volume-size-gb",
+		Value:    50,
+		Usage:    "Boot volume size in GB",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_BOOT_VOLUME_SIZE_GB"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "oracle-freeform-tags",
+		Usage:    "Freeform tags for instances (key=value format)",
+		Sources:  cli.EnvVars("WOODPECKER_ORACLE_FREEFORM_TAGS"),
+		Category: category,
+	},
+}

--- a/providers/oracle/provider.go
+++ b/providers/oracle/provider.go
@@ -1,0 +1,274 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+type Provider struct {
+	name               string
+	region             string
+	compartmentOCID    string
+	availabilityDomain string
+	subnetOCID         string
+	shape              string
+	ocpus              int
+	memoryGB           int
+	imageOCID          string
+	sshPublicKey       string
+	bootVolumeSizeGB   int
+	freeformTags       map[string]string
+	config             *config.Config
+	userDataTemplate   *template.Template
+	computeClient      core.ComputeClient
+}
+
+func New(ctx context.Context, c *cli.Command, config *config.Config) (engine.Provider, error) {
+	p := &Provider{
+		name:               "oracle",
+		region:             c.String("oracle-region"),
+		compartmentOCID:    c.String("oracle-compartment-ocid"),
+		availabilityDomain: c.String("oracle-availability-domain"),
+		subnetOCID:         c.String("oracle-subnet-ocid"),
+		shape:              c.String("oracle-shape"),
+		ocpus:              int(c.Int("oracle-ocpus")),
+		memoryGB:           int(c.Int("oracle-memory-gb")),
+		imageOCID:          c.String("oracle-image-ocid"),
+		sshPublicKey:       c.String("oracle-ssh-public-key"),
+		bootVolumeSizeGB:   int(c.Int("oracle-boot-volume-size-gb")),
+		config:             config,
+	}
+
+	// Parse freeform tags
+	p.freeformTags = make(map[string]string)
+	p.freeformTags["woodpecker-pool"] = config.PoolID
+
+	for _, tag := range c.StringSlice("oracle-freeform-tags") {
+		parts := strings.SplitN(tag, "=", 2)
+		if len(parts) == 2 {
+			p.freeformTags[parts[0]] = parts[1]
+		}
+	}
+
+	// Create OCI configuration provider
+	configProvider := common.NewRawConfigurationProvider(
+		c.String("oracle-tenancy-ocid"),
+		c.String("oracle-user-ocid"),
+		p.region,
+		c.String("oracle-fingerprint"),
+		c.String("oracle-private-key"),
+		nil,
+	)
+
+	// Create compute client
+	computeClient, err := core.NewComputeClientWithConfigurationProvider(configProvider)
+	if err != nil {
+		return nil, fmt.Errorf("%s: NewComputeClientWithConfigurationProvider: %w", p.name, err)
+	}
+	p.computeClient = computeClient
+
+	return p, nil
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := engine.RenderUserDataTemplate(p.config, agent, p.userDataTemplate)
+	if err != nil {
+		return fmt.Errorf("%s: engine.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	// Base64 encode the user data for cloud-init
+	userDataEncoded := base64.StdEncoding.EncodeToString([]byte(userData))
+
+	// Build SSH authorized keys
+	var sshKeys map[string]string
+	if p.sshPublicKey != "" {
+		sshKeys = map[string]string{
+			"ssh_authorized_keys": p.sshPublicKey,
+		}
+	}
+
+	// Prepare instance metadata
+	metadata := map[string]string{
+		"user_data": userDataEncoded,
+	}
+	if p.sshPublicKey != "" {
+		metadata["ssh_authorized_keys"] = p.sshPublicKey
+	}
+
+	// Build shape config for flexible shapes
+	var shapeConfig *core.LaunchInstanceShapeConfigDetails
+	if strings.Contains(p.shape, "Flex") {
+		ocpus := float32(p.ocpus)
+		memoryGB := float32(p.memoryGB)
+		shapeConfig = &core.LaunchInstanceShapeConfigDetails{
+			Ocpus:       &ocpus,
+			MemoryInGBs: &memoryGB,
+		}
+	}
+
+	// Build boot volume config
+	bootVolumeSizeGB := int64(p.bootVolumeSizeGB)
+	sourceDetails := core.InstanceSourceViaImageDetails{
+		ImageId:             &p.imageOCID,
+		BootVolumeSizeInGBs: &bootVolumeSizeGB,
+	}
+
+	// Create launch instance request
+	launchRequest := core.LaunchInstanceRequest{
+		LaunchInstanceDetails: core.LaunchInstanceDetails{
+			AvailabilityDomain: &p.availabilityDomain,
+			CompartmentId:      &p.compartmentOCID,
+			DisplayName:        &agent.Name,
+			Shape:              &p.shape,
+			ShapeConfig:        shapeConfig,
+			SourceDetails:      sourceDetails,
+			CreateVnicDetails: &core.CreateVnicDetails{
+				SubnetId:       &p.subnetOCID,
+				AssignPublicIp: common.Bool(true),
+			},
+			Metadata:     metadata,
+			FreeformTags: p.freeformTags,
+		},
+	}
+
+	// Launch the instance
+	response, err := p.computeClient.LaunchInstance(ctx, launchRequest)
+	if err != nil {
+		return fmt.Errorf("%s: LaunchInstance: %w", p.name, err)
+	}
+
+	log.Info().
+		Str("agent", agent.Name).
+		Str("instance_id", *response.Instance.Id).
+		Msg("instance created")
+
+	return nil
+}
+
+func (p *Provider) getInstance(ctx context.Context, agent *woodpecker.Agent) (*core.Instance, error) {
+	// List instances in compartment
+	listRequest := core.ListInstancesRequest{
+		CompartmentId:  &p.compartmentOCID,
+		DisplayName:    &agent.Name,
+		LifecycleState: core.InstanceLifecycleStateRunning,
+	}
+
+	response, err := p.computeClient.ListInstances(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("%s: ListInstances: %w", p.name, err)
+	}
+
+	for _, instance := range response.Items {
+		if *instance.DisplayName == agent.Name {
+			return &instance, nil
+		}
+	}
+
+	// Also check for instances in STARTING state
+	listRequest.LifecycleState = core.InstanceLifecycleStateStarting
+	response, err = p.computeClient.ListInstances(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("%s: ListInstances: %w", p.name, err)
+	}
+
+	for _, instance := range response.Items {
+		if *instance.DisplayName == agent.Name {
+			return &instance, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	instance, err := p.getInstance(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("%s: getInstance: %w", p.name, err)
+	}
+
+	if instance == nil {
+		log.Debug().Str("agent", agent.Name).Msg("instance not found, nothing to remove")
+		return nil
+	}
+
+	// Terminate the instance
+	terminateRequest := core.TerminateInstanceRequest{
+		InstanceId:         instance.Id,
+		PreserveBootVolume: common.Bool(false),
+	}
+
+	_, err = p.computeClient.TerminateInstance(ctx, terminateRequest)
+	if err != nil {
+		return fmt.Errorf("%s: TerminateInstance: %w", p.name, err)
+	}
+
+	log.Info().
+		Str("agent", agent.Name).
+		Str("instance_id", *instance.Id).
+		Msg("instance terminated")
+
+	return nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	var names []string
+
+	// List all running instances in the compartment
+	listRequest := core.ListInstancesRequest{
+		CompartmentId:  &p.compartmentOCID,
+		LifecycleState: core.InstanceLifecycleStateRunning,
+	}
+
+	response, err := p.computeClient.ListInstances(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("%s: ListInstances: %w", p.name, err)
+	}
+
+	for _, instance := range response.Items {
+		// Check if this instance belongs to our pool
+		if poolID, ok := instance.FreeformTags["woodpecker-pool"]; ok && poolID == p.config.PoolID {
+			names = append(names, *instance.DisplayName)
+		}
+	}
+
+	// Also include instances in STARTING state
+	listRequest.LifecycleState = core.InstanceLifecycleStateStarting
+	response, err = p.computeClient.ListInstances(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("%s: ListInstances (starting): %w", p.name, err)
+	}
+
+	for _, instance := range response.Items {
+		if poolID, ok := instance.FreeformTags["woodpecker-pool"]; ok && poolID == p.config.PoolID {
+			names = append(names, *instance.DisplayName)
+		}
+	}
+
+	return names, nil
+}


### PR DESCRIPTION
## Summary

Add Oracle Cloud Infrastructure (OCI) as a new cloud provider for the autoscaler. This allows users to automatically scale Woodpecker CI agents using Oracle Cloud compute instances.

## Features

- Full OCI Compute integration for instance lifecycle management
- Support for flexible shapes (VM.Standard.E4.Flex, VM.Standard.A1.Flex, etc.)
- Configurable OCPUs and memory for flexible shapes
- Boot volume size configuration
- Freeform tags support for resource organization
- SSH public key support for instance access
- Pool-based instance filtering using freeform tags

## Configuration

The following environment variables/flags are available:

| Flag | Environment Variable | Description |
|------|---------------------|-------------|
| `--oracle-tenancy-ocid` | `WOODPECKER_ORACLE_TENANCY_OCID` | Oracle Cloud tenancy OCID |
| `--oracle-user-ocid` | `WOODPECKER_ORACLE_USER_OCID` | Oracle Cloud user OCID |
| `--oracle-fingerprint` | `WOODPECKER_ORACLE_FINGERPRINT` | API key fingerprint |
| `--oracle-private-key` | `WOODPECKER_ORACLE_PRIVATE_KEY` | API private key (PEM) |
| `--oracle-region` | `WOODPECKER_ORACLE_REGION` | Region (default: us-ashburn-1) |
| `--oracle-compartment-ocid` | `WOODPECKER_ORACLE_COMPARTMENT_OCID` | Compartment OCID |
| `--oracle-availability-domain` | `WOODPECKER_ORACLE_AVAILABILITY_DOMAIN` | Availability domain |
| `--oracle-subnet-ocid` | `WOODPECKER_ORACLE_SUBNET_OCID` | Subnet OCID |
| `--oracle-shape` | `WOODPECKER_ORACLE_SHAPE` | Instance shape (default: VM.Standard.E4.Flex) |
| `--oracle-ocpus` | `WOODPECKER_ORACLE_OCPUS` | Number of OCPUs (default: 1) |
| `--oracle-memory-gb` | `WOODPECKER_ORACLE_MEMORY_GB` | Memory in GB (default: 4) |
| `--oracle-image-ocid` | `WOODPECKER_ORACLE_IMAGE_OCID` | Image OCID |
| `--oracle-ssh-public-key` | `WOODPECKER_ORACLE_SSH_PUBLIC_KEY` | SSH public key |
| `--oracle-boot-volume-size-gb` | `WOODPECKER_ORACLE_BOOT_VOLUME_SIZE_GB` | Boot volume size (default: 50) |
| `--oracle-freeform-tags` | `WOODPECKER_ORACLE_FREEFORM_TAGS` | Freeform tags (key=value) |

## Closes

Closes #102

## Checklist

- [x] Code follows the project's style guidelines
- [x] Implements the Provider interface (DeployAgent, RemoveAgent, ListDeployedAgentNames)
- [x] Added CLI flags with environment variable support
- [x] Updated README.md roadmap