### PR TITLE
feat(providers): add DigitalOcean autoscaler support

### DIFF
--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -15,6 +15,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/config"
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/digitalocean"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
@@ -26,6 +27,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	switch cmd.String("provider") {
 	case "aws":
 		return aws.New(ctx, cmd, config)
+	case "digitalocean":
+		return digitalocean.New(ctx, cmd, config)
 	case "hetznercloud":
 		return hetznercloud.New(ctx, cmd, config)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
@@ -135,12 +138,13 @@ func main() {
 		Action: run,
 	}
 
+	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, digitalocean.ProviderFlags...)
 	app.Flags = append(app.Flags, hetznercloud.ProviderFlags...)
-	app.Flags = append(app.Flags, scaleway.ProviderFlags...)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
 	// Enable it again when the issue is fixed.
 	// app.Flags = append(app.Flags, linode.ProviderFlags...)
-	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, scaleway.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.285.0
+	github.com/digitalocean/godo v1.173.0
 	github.com/docker/go-units v0.5.0
 	github.com/hetznercloud/hcloud-go/v2 v2.36.0
 	github.com/joho/godotenv v1.5.1
@@ -55,6 +56,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/godo v1.173.0 h1:tgzevGhlz9VFjk2y3NmeItUT4vIVVCRFETlG/1GlEQI=
+github.com/digitalocean/godo v1.173.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/providers/digitalocean/flags.go
+++ b/providers/digitalocean/flags.go
@@ -1,0 +1,74 @@
+package digitalocean
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "DigitalOcean"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "digitalocean-api-token",
+		Usage: "DigitalOcean API token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-region",
+		Value:    "nyc1",
+		Usage:    "DigitalOcean region (e.g., nyc1, sfo3, ams3)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-size",
+		Value:    "s-1vcpu-1gb",
+		Usage:    "DigitalOcean droplet size",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SIZE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-image",
+		Value:    "ubuntu-22-04-x64",
+		Usage:    "DigitalOcean image slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IMAGE"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-ssh-keys",
+		Usage:    "DigitalOcean SSH key names or fingerprints",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SSH_KEYS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-tags",
+		Usage:    "DigitalOcean droplet tags",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_TAGS"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-ipv6",
+		Value:    false,
+		Usage:    "Enable IPv6 for droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IPV6"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-monitoring",
+		Value:    true,
+		Usage:    "Enable monitoring for droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_MONITORING"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-vpc-uuid",
+		Usage:    "DigitalOcean VPC UUID (optional)",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_VPC_UUID"),
+		Category: category,
+	},
+}

--- a/providers/digitalocean/provider.go
+++ b/providers/digitalocean/provider.go
@@ -1,0 +1,246 @@
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/digitalocean/godo"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+	"golang.org/x/exp/maps"
+	"golang.org/x/oauth2"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var (
+	ErrIllegalLabelPrefix = errors.New("illegal label prefix")
+	ErrSSHKeyNotFound     = errors.New("SSH key not found")
+)
+
+type Provider struct {
+	name             string
+	region           string
+	size             string
+	image            string
+	sshKeys          []godo.DropletCreateSSHKey
+	tags             []string
+	labels           map[string]string
+	enableIPv6       bool
+	enableMonitoring bool
+	vpcUUID          string
+	userDataTemplate *template.Template
+	config           *config.Config
+	client           *godo.Client
+}
+
+func New(ctx context.Context, c *cli.Command, config *config.Config) (engine.Provider, error) {
+	p := &Provider{
+		name:             "digitalocean",
+		region:           c.String("digitalocean-region"),
+		size:             c.String("digitalocean-size"),
+		image:            c.String("digitalocean-image"),
+		enableIPv6:       c.Bool("digitalocean-ipv6"),
+		enableMonitoring: c.Bool("digitalocean-monitoring"),
+		vpcUUID:          c.String("digitalocean-vpc-uuid"),
+		config:           config,
+	}
+
+	// Setup OAuth2 client
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.String("digitalocean-api-token")})
+	oauthClient := oauth2.NewClient(ctx, tokenSource)
+	p.client = godo.NewClient(oauthClient)
+
+	// Setup SSH keys
+	if err := p.setupSSHKeys(ctx, c.StringSlice("digitalocean-ssh-keys")); err != nil {
+		return nil, fmt.Errorf("%s: setupSSHKeys: %w", p.name, err)
+	}
+
+	// Setup default labels/tags
+	defaultLabels := make(map[string]string)
+	defaultLabels[engine.LabelPool] = p.config.PoolID
+	defaultLabels[engine.LabelImage] = p.image
+
+	// Parse user-provided labels
+	labels, err := engine.SliceToMap(c.StringSlice("digitalocean-tags"), "=")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", p.name, err)
+	}
+
+	for _, key := range maps.Keys(labels) {
+		if strings.HasPrefix(key, engine.LabelPrefix) {
+			return nil, fmt.Errorf("%s: %w: %s", p.name, ErrIllegalLabelPrefix, engine.LabelPrefix)
+		}
+	}
+	p.labels = engine.MergeMaps(defaultLabels, labels)
+
+	// Convert labels to DigitalOcean tags (they don't support key=value, so we encode it)
+	p.tags = make([]string, 0, len(p.labels))
+	for key, value := range p.labels {
+		// DigitalOcean tags have restrictions: lowercase, alphanumeric, hyphens, underscores, colons
+		// We encode as key:value format
+		tag := sanitizeTag(fmt.Sprintf("%s:%s", key, value))
+		p.tags = append(p.tags, tag)
+	}
+
+	return p, nil
+}
+
+// sanitizeTag converts a string to a valid DigitalOcean tag
+func sanitizeTag(s string) string {
+	// Replace / with - and = with :
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.ReplaceAll(s, "=", ":")
+	// Lowercase
+	s = strings.ToLower(s)
+	return s
+}
+
+func (p *Provider) setupSSHKeys(ctx context.Context, keyNames []string) error {
+	keys, _, err := p.client.Keys.List(ctx, &godo.ListOptions{PerPage: 200}) //nolint:mnd
+	if err != nil {
+		return err
+	}
+
+	// If specific keys requested, find them
+	if len(keyNames) > 0 {
+		for _, name := range keyNames {
+			found := false
+			for _, key := range keys {
+				if key.Name == name || key.Fingerprint == name {
+					p.sshKeys = append(p.sshKeys, godo.DropletCreateSSHKey{ID: key.ID})
+					found = true
+					break
+				}
+			}
+			if !found {
+				log.Warn().Msgf("SSH key not found: %s", name)
+			}
+		}
+		if len(p.sshKeys) > 0 {
+			return nil
+		}
+	}
+
+	// Try to find keys by naming convention
+	index := make(map[string]int)
+	for _, key := range keys {
+		index[key.Name] = key.ID
+	}
+
+	for _, name := range []string{"woodpecker", "id_rsa_woodpecker"} {
+		if id, ok := index[name]; ok {
+			p.sshKeys = append(p.sshKeys, godo.DropletCreateSSHKey{ID: id})
+			return nil
+		}
+	}
+
+	// Use first available key if any
+	if len(keys) > 0 {
+		p.sshKeys = append(p.sshKeys, godo.DropletCreateSSHKey{ID: keys[0].ID})
+		return nil
+	}
+
+	return ErrSSHKeyNotFound
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := engine.RenderUserDataTemplate(p.config, agent, p.userDataTemplate)
+	if err != nil {
+		return fmt.Errorf("%s: engine.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	createRequest := &godo.DropletCreateRequest{
+		Name:       agent.Name,
+		Region:     p.region,
+		Size:       p.size,
+		Image:      godo.DropletCreateImage{Slug: p.image},
+		SSHKeys:    p.sshKeys,
+		IPv6:       p.enableIPv6,
+		Monitoring: p.enableMonitoring,
+		UserData:   userData,
+		Tags:       p.tags,
+	}
+
+	if p.vpcUUID != "" {
+		createRequest.VPCUUID = p.vpcUUID
+	}
+
+	_, _, err = p.client.Droplets.Create(ctx, createRequest)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Create: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) getAgent(ctx context.Context, agent *woodpecker.Agent) (*godo.Droplet, error) {
+	// List droplets and find by name
+	droplets, _, err := p.client.Droplets.ListByName(ctx, agent.Name, &godo.ListOptions{PerPage: 200}) //nolint:mnd
+	if err != nil {
+		return nil, fmt.Errorf("%s: Droplets.ListByName: %w", p.name, err)
+	}
+
+	if len(droplets) == 0 {
+		return nil, nil
+	}
+
+	return &droplets[0], nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	droplet, err := p.getAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("%s: getAgent: %w", p.name, err)
+	}
+
+	if droplet == nil {
+		return nil
+	}
+
+	_, err = p.client.Droplets.Delete(ctx, droplet.ID)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Delete: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	var names []string
+	var droplets []godo.Droplet
+
+	// Create tag for filtering by pool
+	poolTag := sanitizeTag(fmt.Sprintf("%s:%s", engine.LabelPool, p.config.PoolID))
+
+	opt := &godo.ListOptions{PerPage: 200} //nolint:mnd
+	for {
+		page, resp, err := p.client.Droplets.ListByTag(ctx, poolTag, opt)
+		if err != nil {
+			return nil, fmt.Errorf("%s: Droplets.ListByTag: %w", p.name, err)
+		}
+
+		droplets = append(droplets, page...)
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		nextPage, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("%s: parsing pagination: %w", p.name, err)
+		}
+		opt.Page = nextPage + 1
+	}
+
+	for _, droplet := range droplets {
+		names = append(names, droplet.Name)
+	}
+
+	return names, nil
+}

--- a/providers/digitalocean/provider_test.go
+++ b/providers/digitalocean/provider_test.go
@@ -1,0 +1,58 @@
+package digitalocean
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple tag",
+			input:    "test",
+			expected: "test",
+		},
+		{
+			name:     "Tag with slash",
+			input:    "wp.autoscaler/pool",
+			expected: "wp.autoscaler-pool",
+		},
+		{
+			name:     "Tag with equals",
+			input:    "key=value",
+			expected: "key:value",
+		},
+		{
+			name:     "Complex tag",
+			input:    "wp.autoscaler/pool:mypool",
+			expected: "wp.autoscaler-pool:mypool",
+		},
+		{
+			name:     "Uppercase to lowercase",
+			input:    "MyTag",
+			expected: "mytag",
+		},
+		{
+			name:     "Full label format",
+			input:    "wp.autoscaler/pool=production",
+			expected: "wp.autoscaler-pool:production",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeTag(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProviderName(t *testing.T) {
+	p := &Provider{name: "digitalocean"}
+	assert.Equal(t, "digitalocean", p.name)
+}


### PR DESCRIPTION
## Summary

Implements DigitalOcean Droplets provider following the existing pattern (Hetzner, Vultr, Linode, etc.).

### Features
- Create/delete droplets via DigitalOcean API (godo SDK)
- SSH key auto-detection (woodpecker naming convention)
- Tag-based filtering for pool management
- Support for regions, sizes, images, VPC, IPv6, monitoring
- Cloud-init user data for agent provisioning

### Configuration Options
| Flag | Default | Description |
|------|---------|-------------|
| `--digitalocean-api-token` | - | DigitalOcean API token |
| `--digitalocean-region` | `nyc1` | Region (e.g., nyc1, sfo3, ams3) |
| `--digitalocean-size` | `s-1vcpu-1gb` | Droplet size |
| `--digitalocean-image` | `ubuntu-22-04-x64` | Image slug |
| `--digitalocean-ssh-keys` | - | SSH key names/fingerprints |
| `--digitalocean-tags` | - | Droplet tags |
| `--digitalocean-ipv6` | `false` | Enable IPv6 |
| `--digitalocean-monitoring` | `true` | Enable monitoring |
| `--digitalocean-vpc-uuid` | - | VPC UUID (optional) |

## Test Plan
- [x] Unit tests for tag sanitization
- [x] All existing tests pass
- [x] Linting passes (golangci-lint)
- [x] Builds successfully

Closes #103

/claim #103