### PR TITLE
feat: add DigitalOcean as a cloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The agents will use `WOODPECKER_GRPC_ADDR` and a token automatically generated b
   - [x] Amazon AWS
   - [ ] Google Cloud
   - [ ] Azure
-  - [ ] Digital Ocean
+  - [x] Digital Ocean
   - [x] Linode (temp disabled until the [security issue](https://github.com/woodpecker-ci/autoscaler/issues/91) was addressed)
   - [ ] Oracle Cloud
   - [ ] Equinix Metal

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -15,6 +15,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/config"
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/digitalocean"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
@@ -34,6 +35,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	// 	return linode.New(ctx, config)
 	case "vultr":
 		return vultr.New(ctx, cmd, config)
+	case "digitalocean":
+		return digitalocean.New(ctx, cmd, config)
 	case "scaleway":
 		return scaleway.New(ctx, cmd, config)
 	case "":
@@ -142,6 +145,7 @@ func main() {
 	// app.Flags = append(app.Flags, linode.ProviderFlags...)
 	app.Flags = append(app.Flags, aws.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
+	app.Flags = append(app.Flags, digitalocean.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Error().Err(err).Msg("got error while try to run autoscaler")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.296.0
+	github.com/digitalocean/godo v1.178.0
 	github.com/docker/go-units v0.5.0
 	github.com/hetznercloud/hcloud-go/v2 v2.36.0
 	github.com/joho/godotenv v1.5.1
@@ -55,6 +56,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/godo v1.178.0 h1:+B4xGOaoFwwwpM7TKhoyGHdmFg5eF9zDB1YfOLvNJ2E=
+github.com/digitalocean/godo v1.178.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/providers/digitalocean/flags.go
+++ b/providers/digitalocean/flags.go
@@ -1,0 +1,71 @@
+package digitalocean
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "DigitalOcean"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "digitalocean-api-token",
+		Usage: "DigitalOcean api token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-region",
+		Value:    "nyc1",
+		Usage:    "DigitalOcean region",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-size",
+		Value:    "s-1vcpu-1gb",
+		Usage:    "DigitalOcean droplet size",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SIZE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-image",
+		Value:    "ubuntu-24-04-x64",
+		Usage:    "DigitalOcean image slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IMAGE"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-ssh-keys",
+		Usage:    "DigitalOcean SSH key fingerprints or IDs",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SSH_KEYS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-tags",
+		Usage:    "DigitalOcean droplet tags",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_TAGS"),
+		Category: category,
+	},
+	// TODO: Deprecated remove in v2.0
+	&cli.StringFlag{
+		Name:  "digitalocean-user-data",
+		Usage: "DigitalOcean userdata template (deprecated)",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_USERDATA"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_USERDATA_FILE")),
+		),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-ipv6",
+		Value:    true,
+		Usage:    "enable IPv6 for DigitalOcean droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IPV6"),
+		Category: category,
+	},
+}

--- a/providers/digitalocean/provider.go
+++ b/providers/digitalocean/provider.go
@@ -1,0 +1,178 @@
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"text/template"
+
+	"github.com/digitalocean/godo"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var (
+	ErrSSHKeyNotFound = errors.New("SSH key not found")
+)
+
+type Provider struct {
+	name             string
+	region           string
+	size             string
+	image            string
+	enableIPv6       bool
+	sshKeys          []godo.DropletCreateSSHKey
+	tags             []string
+	userDataTemplate *template.Template
+	config           *config.Config
+	client           *godo.Client
+}
+
+func New(_ context.Context, c *cli.Command, config *config.Config) (engine.Provider, error) {
+	p := &Provider{
+		name:       "digitalocean",
+		region:     c.String("digitalocean-region"),
+		size:       c.String("digitalocean-size"),
+		image:      c.String("digitalocean-image"),
+		enableIPv6: c.Bool("digitalocean-ipv6"),
+		config:     config,
+	}
+
+	p.client = godo.NewFromToken(c.String("digitalocean-api-token"))
+
+	// parse SSH keys (can be IDs or fingerprints)
+	for _, key := range c.StringSlice("digitalocean-ssh-keys") {
+		if id, err := strconv.Atoi(key); err == nil {
+			p.sshKeys = append(p.sshKeys, godo.DropletCreateSSHKey{ID: id})
+		} else {
+			p.sshKeys = append(p.sshKeys, godo.DropletCreateSSHKey{Fingerprint: key})
+		}
+	}
+
+	// # TODO: Deprecated remove in v2.0
+	if u := c.String("digitalocean-user-data"); u != "" {
+		log.Warn().Msg("digitalocean-user-data is deprecated, please use provider-user-data instead")
+		userDataTmpl, err := template.New("user-data").Parse(u)
+		if err != nil {
+			return nil, fmt.Errorf("%s: template.New.Parse %w", p.name, err)
+		}
+		p.userDataTemplate = userDataTmpl
+	}
+
+	// pool tag is always added to identify managed droplets
+	p.tags = append([]string{engine.LabelPool + "=" + config.PoolID}, c.StringSlice("digitalocean-tags")...)
+
+	return p, nil
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := engine.RenderUserDataTemplate(p.config, agent, p.userDataTemplate)
+	if err != nil {
+		return fmt.Errorf("%s: engine.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	createReq := &godo.DropletCreateRequest{
+		Name:   agent.Name,
+		Region: p.region,
+		Size:   p.size,
+		Image: godo.DropletCreateImage{
+			Slug: p.image,
+		},
+		SSHKeys:  p.sshKeys,
+		UserData: userData,
+		Tags:     p.tags,
+		IPv6:     p.enableIPv6,
+	}
+
+	_, _, err = p.client.Droplets.Create(ctx, createReq)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Create: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) getAgent(ctx context.Context, agent *woodpecker.Agent) (*godo.Droplet, error) {
+	// list droplets filtered by the pool tag
+	droplets, err := p.listAllDroplets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, d := range droplets {
+		if d.Name == agent.Name {
+			return &d, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	droplet, err := p.getAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("%s: getAgent: %w", p.name, err)
+	}
+
+	if droplet == nil {
+		return nil
+	}
+
+	_, err = p.client.Droplets.Delete(ctx, droplet.ID)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Delete: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	droplets, err := p.listAllDroplets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(droplets))
+	for _, d := range droplets {
+		names = append(names, d.Name)
+	}
+
+	return names, nil
+}
+
+func (p *Provider) listAllDroplets(ctx context.Context) ([]godo.Droplet, error) {
+	var allDroplets []godo.Droplet
+
+	poolTag := engine.LabelPool + "=" + p.config.PoolID
+
+	opt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200, //nolint:mnd
+	}
+
+	for {
+		droplets, resp, err := p.client.Droplets.ListByTag(ctx, poolTag, opt)
+		if err != nil {
+			return nil, fmt.Errorf("%s: Droplets.ListByTag: %w", p.name, err)
+		}
+
+		allDroplets = append(allDroplets, droplets...)
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("%s: CurrentPage: %w", p.name, err)
+		}
+		opt.Page = page + 1
+	}
+
+	return allDroplets, nil
+}


### PR DESCRIPTION
## Summary
- Adds DigitalOcean as a new cloud provider using the [godo](https://github.com/digitalocean/godo) SDK
- Follows the same pattern as existing providers (Vultr, Hetzner Cloud, Scaleway, AWS)
- Implements all three `engine.Provider` interface methods: `DeployAgent`, `RemoveAgent`, `ListDeployedAgentNames`

## Configuration

| Flag | Env Var | Default | Description |
|------|---------|---------|-------------|
| `--digitalocean-api-token` | `WOODPECKER_DIGITALOCEAN_API_TOKEN` | - | API token |
| `--digitalocean-region` | `WOODPECKER_DIGITALOCEAN_REGION` | `nyc1` | Region |
| `--digitalocean-size` | `WOODPECKER_DIGITALOCEAN_SIZE` | `s-1vcpu-1gb` | Droplet size |
| `--digitalocean-image` | `WOODPECKER_DIGITALOCEAN_IMAGE` | `ubuntu-24-04-x64` | Image slug |
| `--digitalocean-ssh-keys` | `WOODPECKER_DIGITALOCEAN_SSH_KEYS` | - | SSH key fingerprints or IDs |
| `--digitalocean-tags` | `WOODPECKER_DIGITALOCEAN_TAGS` | - | Additional droplet tags |
| `--digitalocean-ipv6` | `WOODPECKER_DIGITALOCEAN_IPV6` | `true` | Enable IPv6 |
| `--digitalocean-user-data` | `WOODPECKER_DIGITALOCEAN_USERDATA` | - | Custom userdata template (deprecated, use `provider-user-data`) |

## Implementation details
- Uses `Droplets.ListByTag` for efficient filtering of managed droplets by pool ID tag
- Supports pagination for listing droplets
- SSH keys can be specified as numeric IDs or fingerprints
- Cloud-init user data is rendered using the shared `engine.RenderUserDataTemplate`
- Pool identification uses the same tag convention as other providers (`wp.autoscaler/pool=<pool-id>`)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt` clean
- [ ] Manual test with a DigitalOcean account

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)