### PR TITLE
Add DigitalOcean autoscaler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The agents will use `WOODPECKER_GRPC_ADDR` and a token automatically generated b
   - [x] Amazon AWS
   - [ ] Google Cloud
   - [ ] Azure
-  - [ ] Digital Ocean
+  - [x] Digital Ocean
   - [x] Linode (temp disabled until the [security issue](https://github.com/woodpecker-ci/autoscaler/issues/91) was addressed)
   - [ ] Oracle Cloud
   - [ ] Equinix Metal

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -15,6 +15,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/config"
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/digitalocean"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
@@ -34,6 +35,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	// 	return linode.New(ctx, config)
 	case "vultr":
 		return vultr.New(ctx, cmd, config)
+	case "digitalocean":
+		return digitalocean.New(ctx, cmd, config)
 	case "scaleway":
 		return scaleway.New(ctx, cmd, config)
 	case "":
@@ -141,6 +144,7 @@ func main() {
 	// Enable it again when the issue is fixed.
 	// app.Flags = append(app.Flags, linode.ProviderFlags...)
 	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, digitalocean.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.0
+	github.com/digitalocean/godo v1.184.0
 	github.com/docker/go-units v0.5.0
 	github.com/hetznercloud/hcloud-go/v2 v2.37.0
 	github.com/joho/godotenv v1.5.1
@@ -55,6 +56,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/godo v1.184.0 h1:2B2CQhxftlf3xa24Nrzn5CBQlaQjyaWqi3XbbnJlG3w=
+github.com/digitalocean/godo v1.184.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/providers/digitalocean/flags.go
+++ b/providers/digitalocean/flags.go
@@ -1,0 +1,77 @@
+package digitalocean
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "DigitalOcean"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "digitalocean-api-token",
+		Usage: "DigitalOcean API token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-region",
+		Value:    "nyc1",
+		Usage:    "DigitalOcean region slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-size",
+		Value:    "s-1vcpu-1gb",
+		Usage:    "DigitalOcean droplet size slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SIZE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-image",
+		Value:    "ubuntu-22-04-x64",
+		Usage:    "DigitalOcean image slug or ID",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IMAGE"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-ssh-keys",
+		Usage:    "DigitalOcean SSH key fingerprints or IDs",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SSH_KEYS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-tags",
+		Usage:    "DigitalOcean droplet tags",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_TAGS"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-ipv6",
+		Value:    false,
+		Usage:    "enable IPv6 for droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IPV6"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-vpc-uuid",
+		Usage:    "DigitalOcean VPC UUID",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_VPC_UUID"),
+		Category: category,
+	},
+	// TODO: Deprecated remove in v2.0
+	&cli.StringFlag{
+		Name:  "digitalocean-user-data",
+		Usage: "DigitalOcean userdata template (deprecated)",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_USERDATA"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_USERDATA_FILE")),
+		),
+		Category: category,
+	},
+}

--- a/providers/digitalocean/provider.go
+++ b/providers/digitalocean/provider.go
@@ -1,0 +1,203 @@
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/digitalocean/godo"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var (
+	ErrIllegalLabelPrefix = errors.New("illegal label prefix")
+)
+
+// DropletsService abstracts the godo.DropletsService for testability.
+type DropletsService interface {
+	Create(ctx context.Context, createRequest *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error)
+	Delete(ctx context.Context, dropletID int) (*godo.Response, error)
+	List(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
+}
+
+type Provider struct {
+	name             string
+	region           string
+	size             string
+	image            string
+	sshKeys          []string
+	tags             []string
+	enableIPv6       bool
+	vpcUUID          string
+	userDataTemplate *template.Template
+	config           *config.Config
+	droplets         DropletsService
+}
+
+func New(_ context.Context, c *cli.Command, cfg *config.Config) (engine.Provider, error) {
+	token := c.String("digitalocean-api-token")
+	client := godo.NewFromToken(token)
+
+	p := &Provider{
+		name:       "digitalocean",
+		region:     c.String("digitalocean-region"),
+		size:       c.String("digitalocean-size"),
+		image:      c.String("digitalocean-image"),
+		sshKeys:    c.StringSlice("digitalocean-ssh-keys"),
+		enableIPv6: c.Bool("digitalocean-ipv6"),
+		vpcUUID:    c.String("digitalocean-vpc-uuid"),
+		config:     cfg,
+		droplets:   client.Droplets,
+	}
+
+	// TODO: Deprecated remove in v2.0
+	if u := c.String("digitalocean-user-data"); u != "" {
+		log.Warn().Msg("digitalocean-user-data is deprecated, please use provider-user-data instead")
+		userDataTmpl, err := template.New("user-data").Parse(u)
+		if err != nil {
+			return nil, fmt.Errorf("%s: template.New.Parse %w", p.name, err)
+		}
+		p.userDataTemplate = userDataTmpl
+	}
+
+	// Build default tags (used for listing deployed agents)
+	defaultTags := []string{
+		fmt.Sprintf("%s=%s", engine.LabelPool, cfg.PoolID),
+		fmt.Sprintf("%s=%s", engine.LabelImage, p.image),
+	}
+
+	userTags := c.StringSlice("digitalocean-tags")
+	for _, tag := range userTags {
+		key, _, _ := strings.Cut(tag, "=")
+		if strings.HasPrefix(key, engine.LabelPrefix) {
+			return nil, fmt.Errorf("%s: %w: %s", p.name, ErrIllegalLabelPrefix, engine.LabelPrefix)
+		}
+	}
+	p.tags = append(defaultTags, userTags...)
+
+	return p, nil
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := engine.RenderUserDataTemplate(p.config, agent, p.userDataTemplate)
+	if err != nil {
+		return fmt.Errorf("%s: engine.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	sshKeys := make([]godo.DropletCreateSSHKey, 0, len(p.sshKeys))
+	for _, key := range p.sshKeys {
+		sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: key})
+	}
+
+	createReq := &godo.DropletCreateRequest{
+		Name:     agent.Name,
+		Region:   p.region,
+		Size:     p.size,
+		UserData: userData,
+		SSHKeys:  sshKeys,
+		Tags:     p.tags,
+		IPv6:     p.enableIPv6,
+		Image: godo.DropletCreateImage{
+			Slug: p.image,
+		},
+	}
+
+	if p.vpcUUID != "" {
+		createReq.VPCUUID = p.vpcUUID
+	}
+
+	log.Info().Msgf("create agent: region = %s size = %s", p.region, p.size)
+
+	_, _, err = p.droplets.Create(ctx, createReq)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Create: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	droplet, err := p.findDropletByName(ctx, agent.Name)
+	if err != nil {
+		return fmt.Errorf("%s: findDropletByName: %w", p.name, err)
+	}
+
+	if droplet == nil {
+		return nil
+	}
+
+	_, err = p.droplets.Delete(ctx, droplet.ID)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Delete: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) findDropletByName(ctx context.Context, name string) (*godo.Droplet, error) {
+	page := 1
+	for {
+		droplets, resp, err := p.droplets.List(ctx, &godo.ListOptions{
+			Page:    page,
+			PerPage: 200, //nolint:mnd
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range droplets {
+			if droplets[i].Name == name {
+				return &droplets[i], nil
+			}
+		}
+
+		if resp == nil || resp.Links == nil || resp.Links.Pages == nil || resp.Links.Pages.Next == "" {
+			break
+		}
+		page++
+	}
+
+	return nil, nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	var names []string
+
+	page := 1
+	for {
+		droplets, resp, err := p.droplets.List(ctx, &godo.ListOptions{
+			Page:    page,
+			PerPage: 200, //nolint:mnd
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%s: Droplets.List: %w", p.name, err)
+		}
+
+		poolTag := fmt.Sprintf("%s=%s", engine.LabelPool, p.config.PoolID)
+		for _, d := range droplets {
+			for _, tag := range d.Tags {
+				if tag == poolTag {
+					names = append(names, d.Name)
+					break
+				}
+			}
+		}
+
+		if resp == nil || resp.Links == nil || resp.Links.Pages == nil || resp.Links.Pages.Next == "" {
+			break
+		}
+		page++
+	}
+
+	return names, nil
+}
+
+// Ensure Provider implements engine.Provider at compile time.
+var _ engine.Provider = (*Provider)(nil)

--- a/providers/digitalocean/provider_test.go
+++ b/providers/digitalocean/provider_test.go
@@ -1,0 +1,288 @@
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"text/template"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+// mockDroplets implements DropletsService for testing.
+type mockDroplets struct {
+	mock.Mock
+}
+
+func (m *mockDroplets) Create(ctx context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
+	args := m.Called(ctx, req)
+	var d *godo.Droplet
+	if v := args.Get(0); v != nil {
+		d = v.(*godo.Droplet)
+	}
+	var r *godo.Response
+	if v := args.Get(1); v != nil {
+		r = v.(*godo.Response)
+	}
+	return d, r, args.Error(2)
+}
+
+func (m *mockDroplets) Delete(ctx context.Context, id int) (*godo.Response, error) {
+	args := m.Called(ctx, id)
+	var r *godo.Response
+	if v := args.Get(0); v != nil {
+		r = v.(*godo.Response)
+	}
+	return r, args.Error(1)
+}
+
+func (m *mockDroplets) List(ctx context.Context, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+	args := m.Called(ctx, opt)
+	var d []godo.Droplet
+	if v := args.Get(0); v != nil {
+		d = v.([]godo.Droplet)
+	}
+	var r *godo.Response
+	if v := args.Get(1); v != nil {
+		r = v.(*godo.Response)
+	}
+	return d, r, args.Error(2)
+}
+
+func TestDeployAgent(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*mockDroplets)
+		userdata      string
+		expectedError string
+	}{
+		{
+			name:          "InvalidUserData",
+			setupMocks:    func(_ *mockDroplets) {},
+			userdata:      "{{.InvalidField}}",
+			expectedError: "RenderUserDataTemplate",
+		},
+		{
+			name: "Success",
+			setupMocks: func(md *mockDroplets) {
+				md.On("Create", mock.Anything, mock.MatchedBy(func(req *godo.DropletCreateRequest) bool {
+					return req.Name == "test-agent" &&
+						req.Region == "nyc1" &&
+						req.Size == "s-1vcpu-1gb" &&
+						req.Image.Slug == "ubuntu-22-04-x64"
+				})).Return(&godo.Droplet{ID: 123}, &godo.Response{}, nil)
+			},
+		},
+		{
+			name: "CreateFails",
+			setupMocks: func(md *mockDroplets) {
+				md.On("Create", mock.Anything, mock.Anything).
+					Return(nil, nil, errors.New("API error"))
+			},
+			expectedError: "Droplets.Create",
+		},
+		{
+			name: "WithSSHKeys",
+			setupMocks: func(md *mockDroplets) {
+				md.On("Create", mock.Anything, mock.MatchedBy(func(req *godo.DropletCreateRequest) bool {
+					return len(req.SSHKeys) == 2 &&
+						req.SSHKeys[0].Fingerprint == "fp1" &&
+						req.SSHKeys[1].Fingerprint == "fp2"
+				})).Return(&godo.Droplet{ID: 124}, &godo.Response{}, nil)
+			},
+		},
+		{
+			name: "WithVPCUUID",
+			setupMocks: func(md *mockDroplets) {
+				md.On("Create", mock.Anything, mock.MatchedBy(func(req *godo.DropletCreateRequest) bool {
+					return req.VPCUUID == "vpc-123"
+				})).Return(&godo.Droplet{ID: 125}, &godo.Response{}, nil)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := new(mockDroplets)
+			tt.setupMocks(md)
+
+			p := &Provider{
+				name:     "digitalocean",
+				region:   "nyc1",
+				size:     "s-1vcpu-1gb",
+				image:    "ubuntu-22-04-x64",
+				config:   &config.Config{},
+				droplets: md,
+				tags: []string{
+					engine.LabelPool + "=test-pool",
+					engine.LabelImage + "=ubuntu-22-04-x64",
+				},
+				userDataTemplate: template.Must(template.New("").Parse(tt.userdata)),
+			}
+
+			if tt.name == "WithSSHKeys" {
+				p.sshKeys = []string{"fp1", "fp2"}
+			}
+			if tt.name == "WithVPCUUID" {
+				p.vpcUUID = "vpc-123"
+			}
+
+			agent := &woodpecker.Agent{Name: "test-agent"}
+			err := p.DeployAgent(t.Context(), agent)
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRemoveAgent(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*mockDroplets)
+		expectedError string
+	}{
+		{
+			name: "Success",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					[]godo.Droplet{{ID: 123, Name: "test-agent"}},
+					&godo.Response{},
+					nil,
+				)
+				md.On("Delete", mock.Anything, 123).
+					Return(&godo.Response{}, nil)
+			},
+		},
+		{
+			name: "NotFound",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					[]godo.Droplet{},
+					&godo.Response{},
+					nil,
+				)
+			},
+		},
+		{
+			name: "ListFails",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					nil, nil, errors.New("API error"),
+				)
+			},
+			expectedError: "findDropletByName",
+		},
+		{
+			name: "DeleteFails",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					[]godo.Droplet{{ID: 123, Name: "test-agent"}},
+					&godo.Response{},
+					nil,
+				)
+				md.On("Delete", mock.Anything, 123).
+					Return(nil, errors.New("API error"))
+			},
+			expectedError: "Droplets.Delete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := new(mockDroplets)
+			tt.setupMocks(md)
+
+			p := &Provider{
+				name:     "digitalocean",
+				config:   &config.Config{},
+				droplets: md,
+			}
+
+			agent := &woodpecker.Agent{Name: "test-agent"}
+			err := p.RemoveAgent(t.Context(), agent)
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestListDeployedAgentNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(*mockDroplets)
+		expected      []string
+		expectedError string
+	}{
+		{
+			name: "ReturnsMatchingAgents",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					[]godo.Droplet{
+						{Name: "agent-1", Tags: []string{engine.LabelPool + "=test-pool"}},
+						{Name: "agent-2", Tags: []string{engine.LabelPool + "=test-pool"}},
+						{Name: "other", Tags: []string{engine.LabelPool + "=other-pool"}},
+					},
+					&godo.Response{},
+					nil,
+				)
+			},
+			expected: []string{"agent-1", "agent-2"},
+		},
+		{
+			name: "EmptyList",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					[]godo.Droplet{},
+					&godo.Response{},
+					nil,
+				)
+			},
+			expected: nil,
+		},
+		{
+			name: "ListFails",
+			setupMocks: func(md *mockDroplets) {
+				md.On("List", mock.Anything, mock.Anything).Return(
+					nil, nil, errors.New("API error"),
+				)
+			},
+			expectedError: "Droplets.List",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			md := new(mockDroplets)
+			tt.setupMocks(md)
+
+			p := &Provider{
+				name:     "digitalocean",
+				config:   &config.Config{PoolID: "test-pool"},
+				droplets: md,
+			}
+
+			names, err := p.ListDeployedAgentNames(t.Context())
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, names)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds DigitalOcean as a cloud provider for the woodpecker-ci autoscaler, using the official [godo](https://github.com/digitalocean/godo) SDK.

Closes #103

## What's implemented

- **`providers/digitalocean/provider.go`** — `Provider` struct implementing `engine.Provider`
  - `DeployAgent` — creates droplets with configurable region, size, image, SSH keys, tags, IPv6, VPC
  - `RemoveAgent` — finds droplet by name via paginated list, then deletes
  - `ListDeployedAgentNames` — lists droplets filtered by pool tag, with pagination support
- **`providers/digitalocean/flags.go`** — CLI flags following the same pattern as other providers
  - `digitalocean-api-token`, `digitalocean-region`, `digitalocean-size`, `digitalocean-image`
  - `digitalocean-ssh-keys`, `digitalocean-tags`, `digitalocean-ipv6`, `digitalocean-vpc-uuid`
  - Deprecated `digitalocean-user-data` (matching the deprecation pattern in other providers)
- **`providers/digitalocean/provider_test.go`** — 12 unit tests with interface-based mocking
  - DeployAgent: invalid userdata, success, create failure, SSH keys, VPC UUID
  - RemoveAgent: success, not found, list failure, delete failure
  - ListDeployedAgentNames: matching agents, empty list, list failure
- **`cmd/woodpecker-autoscaler/main.go`** — wired `digitalocean` case in `setupProvider()` + flags
- **`README.md`** — marked DigitalOcean as implemented

## Design decisions

- Used `DropletsService` interface for testability (same pattern as hetznercloud's `hcapi.Client`)
- `RemoveAgent` uses paginated `List` + name matching since godo's `Droplets.GetByName` is not in the standard interface
- Tags are used for pool identification (similar to Vultr's tag-based filtering)
- Cloud-init user data follows the existing `engine.RenderUserDataTemplate` pattern

## Test plan

- [x] `go test ./providers/digitalocean/...` — 12/12 pass
- [x] `go test ./...` — all existing tests still pass
- [x] `gofmt` — clean
- [x] `go vet` — clean
- [x] `go mod tidy` — clean