### PR TITLE
speedup and improve ci config

### DIFF
--- a/.woodpecker/release.yaml
+++ b/.woodpecker/release.yaml
@@ -6,8 +6,12 @@ when:
 
 variables:
   - &buildx_plugin 'docker.io/woodpeckerci/plugin-docker-buildx:6.0.4'
-  - &repo 'woodpeckerci/autoscaler'
-  - &platforms 'linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le'
+  - &buildx_settings
+    buildkit_oci_max_parallelism: 1
+    dockerfile: docker/Dockerfile
+    repo: 'woodpeckerci/autoscaler'
+    platforms: 'linux/arm/v7,linux/arm64/v8,linux/amd64,linux/ppc64le'
+    tag: test
   - &golang_image 'docker.io/golang:1.26'
 
 steps:
@@ -19,10 +23,8 @@ steps:
   - name: dryrun
     image: *buildx_plugin
     settings:
-      dockerfile: docker/Dockerfile
+      <<: *buildx_settings
       dry_run: true
-      repo: *repo
-      platforms: *platforms
       tag: test
     when:
       - event: pull_request
@@ -30,9 +32,6 @@ steps:
   - name: publish-next
     image: *buildx_plugin
     settings:
-      dockerfile: docker/Dockerfile
-      repo: *repo
-      platforms: *platforms
       tag: next
       username: woodpeckerbot
       password:
@@ -44,9 +43,6 @@ steps:
   - name: publish-tag
     image: *buildx_plugin
     settings:
-      dockerfile: docker/Dockerfile
-      repo: *repo
-      platforms: *platforms
       tag: [latest, '${CI_COMMIT_TAG}']
       username: woodpeckerbot
       password:

--- a/.woodpecker/test.yaml
+++ b/.woodpecker/test.yaml
@@ -21,9 +21,14 @@ variables:
       event: [pull_request, tag, deployment]
 
 steps:
+  - name: vendor
+    image: *golang_image
+    commands:
+      - go mod vendor
+
   - name: lint
     image: *golang_image
-    depends_on: []
+    depends_on: [vendor]
     commands:
       - make lint
     when: *when
@@ -34,7 +39,7 @@ steps:
 
   - name: test
     image: *golang_image
-    depends_on: []
+    depends_on: [vendor]
     commands:
       - make test
     when: *when


### PR DESCRIPTION
the current pipelines fail from time to time, because they just consume to much memory ... we limit concurrent builds to 1 and also use vendor caching for tests...