### PR TITLE
feat(providers): add Equinix Metal provider

### DIFF
--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -16,6 +16,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/engine/types"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/equinixmetal"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
@@ -27,6 +28,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	switch cmd.String("provider") {
 	case "aws":
 		return aws.New(ctx, cmd, config)
+	case "equinixmetal":
+		return equinixmetal.New(ctx, cmd, config)
 	case "hetznercloud":
 		return hetznercloud.New(ctx, cmd, config)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
@@ -168,6 +171,7 @@ func main() {
 	// Enable it again when the issue is fixed.
 	// app.Flags = append(app.Flags, linode.ProviderFlags...)
 	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, equinixmetal.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.0
 	github.com/docker/go-units v0.5.0
+	github.com/equinix/equinix-sdk-go v0.64.0
 	github.com/hetznercloud/hcloud-go/v2 v2.38.0
 	github.com/joho/godotenv v1.5.1
 	github.com/linode/linodego v1.68.0
@@ -57,6 +58,7 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
+	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/equinix/equinix-sdk-go v0.64.0 h1:gGHSorW5lfXBjDZixWhYgJ8DSIv06DYm3U835yjGD1Y=
+github.com/equinix/equinix-sdk-go v0.64.0/go.mod h1:QokAmUtlYlD4gJ1s5UL1nZ4e6XALV0ftl5ZCwdPYp5M=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
@@ -136,6 +138,8 @@ gopkg.in/dnaeon/go-vcr.v4 v4.0.6 h1:PiJkrakkmzc5s7EfBnZOnyiLwi7o7A9fwPzN0X2uwe0=
 gopkg.in/dnaeon/go-vcr.v4 v4.0.6/go.mod h1:sbq5oMEcM4PXngbcNbHhzfCP9OdZodLhrbRYoyg09HY=
 gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
 gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
+gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
+gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/providers/equinixmetal/flags.go
+++ b/providers/equinixmetal/flags.go
@@ -1,0 +1,60 @@
+package equinixmetal
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "Equinix Metal"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "equinixmetal-api-token",
+		Usage: "Equinix Metal API token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_EQUINIXMETAL_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_EQUINIXMETAL_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-project-id",
+		Usage:    "Equinix Metal project ID",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_PROJECT_ID"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-metro",
+		Value:    "sv",
+		Usage:    "Equinix Metal metro code (e.g., sv, da, ny, am)",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_METRO"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-plan",
+		Value:    "c3.small.x86",
+		Usage:    "Equinix Metal server plan",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_PLAN"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-os",
+		Value:    "ubuntu_22_04",
+		Usage:    "Equinix Metal operating system slug",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_OS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "equinixmetal-ssh-keys",
+		Usage:    "SSH key IDs to add to provisioned devices",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_SSH_KEYS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "equinixmetal-tags",
+		Usage:    "Additional device tags in key=value format",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_TAGS"),
+		Category: category,
+	},
+}

--- a/providers/equinixmetal/provider.go
+++ b/providers/equinixmetal/provider.go
@@ -1,0 +1,173 @@
+package equinixmetal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/autoscaler/engine/inits/cloudinit"
+	"go.woodpecker-ci.org/autoscaler/engine/types"
+	"go.woodpecker-ci.org/autoscaler/utils"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var ErrIllegalLabelPrefix = errors.New("illegal label prefix")
+
+// DevicesAPI is the subset of the Equinix Metal API used by this provider.
+// Declared as an interface so tests can inject a mock without a real API token.
+type DevicesAPI interface {
+	CreateDevice(ctx context.Context, projectID string, body metalv1.CreateDeviceRequest) (*metalv1.Device, error)
+	DeleteDevice(ctx context.Context, deviceID string) error
+	FindProjectDevicesByTag(ctx context.Context, projectID string, tag string) ([]metalv1.Device, error)
+}
+
+// sdkClient adapts metalv1.DevicesApiService to satisfy DevicesAPI.
+type sdkClient struct {
+	api *metalv1.DevicesApiService
+}
+
+func (c *sdkClient) CreateDevice(ctx context.Context, projectID string, body metalv1.CreateDeviceRequest) (*metalv1.Device, error) {
+	device, _, err := c.api.CreateDevice(ctx, projectID).CreateDeviceRequest(body).Execute()
+	return device, err
+}
+
+func (c *sdkClient) DeleteDevice(ctx context.Context, deviceID string) error {
+	_, err := c.api.DeleteDevice(ctx, deviceID).Execute()
+	return err
+}
+
+func (c *sdkClient) FindProjectDevicesByTag(ctx context.Context, projectID string, tag string) ([]metalv1.Device, error) {
+	list, err := c.api.FindProjectDevices(ctx, projectID).Tag(tag).ExecuteWithPagination()
+	if err != nil || list == nil {
+		return nil, err
+	}
+	return list.GetDevices(), nil
+}
+
+// Provider implements types.Provider for Equinix Metal.
+type Provider struct {
+	name      string
+	projectID string
+	metro     string
+	plan      string
+	os        string
+	sshKeys   []string
+	labels    map[string]string
+	config    *config.Config
+	client    DevicesAPI
+}
+
+func New(_ context.Context, c *cli.Command, cfg *config.Config) (types.Provider, error) {
+	token := c.String("equinixmetal-api-token")
+	if token == "" {
+		return nil, fmt.Errorf("equinixmetal: api token is required")
+	}
+
+	projectID := c.String("equinixmetal-project-id")
+	if projectID == "" {
+		return nil, fmt.Errorf("equinixmetal: project ID is required")
+	}
+
+	operatingSystem := c.String("equinixmetal-os")
+
+	extraTags, err := utils.SliceToMap(c.StringSlice("equinixmetal-tags"), "=")
+	if err != nil {
+		return nil, fmt.Errorf("equinixmetal: parse tags: %w", err)
+	}
+	for key := range extraTags {
+		if strings.HasPrefix(key, engine.LabelPrefix) {
+			return nil, fmt.Errorf("equinixmetal: %w: %s", ErrIllegalLabelPrefix, engine.LabelPrefix)
+		}
+	}
+
+	defaultLabels := map[string]string{
+		engine.LabelPool:  cfg.PoolID,
+		engine.LabelImage: operatingSystem,
+	}
+
+	metalCfg := metalv1.NewConfiguration()
+	metalCfg.AddDefaultHeader("X-Auth-Token", token)
+	metalCfg.UserAgent = "woodpecker-autoscaler"
+	raw := metalv1.NewAPIClient(metalCfg)
+
+	return &Provider{
+		name:      "equinixmetal",
+		projectID: projectID,
+		metro:     c.String("equinixmetal-metro"),
+		plan:      c.String("equinixmetal-plan"),
+		os:        operatingSystem,
+		sshKeys:   c.StringSlice("equinixmetal-ssh-keys"),
+		labels:    utils.MergeMaps(defaultLabels, extraTags),
+		config:    cfg,
+		client:    &sdkClient{api: raw.DevicesApi},
+	}, nil
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := cloudinit.RenderUserDataTemplate(p.config, agent, nil)
+	if err != nil {
+		return fmt.Errorf("%s: RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	tags := make([]string, 0, len(p.labels))
+	for k, v := range p.labels {
+		tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	input := metalv1.NewDeviceCreateInMetroInput(p.metro, p.os, p.plan)
+	input.SetHostname(agent.Name)
+	input.SetTags(tags)
+	input.SetUserdata(userData)
+	if len(p.sshKeys) > 0 {
+		input.SetProjectSshKeys(p.sshKeys)
+	}
+
+	body := metalv1.DeviceCreateInMetroInputAsCreateDeviceRequest(input)
+	if _, err = p.client.CreateDevice(ctx, p.projectID, body); err != nil {
+		return fmt.Errorf("%s: CreateDevice %q: %w", p.name, agent.Name, err)
+	}
+
+	log.Debug().Str("agent", agent.Name).Str("provider", p.name).Msg("device created")
+	return nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	poolTag := fmt.Sprintf("%s=%s", engine.LabelPool, p.config.PoolID)
+	devices, err := p.client.FindProjectDevicesByTag(ctx, p.projectID, poolTag)
+	if err != nil {
+		return fmt.Errorf("%s: FindProjectDevicesByTag: %w", p.name, err)
+	}
+
+	for _, d := range devices {
+		if d.GetHostname() == agent.Name {
+			if err := p.client.DeleteDevice(ctx, d.GetId()); err != nil {
+				return fmt.Errorf("%s: DeleteDevice %q: %w", p.name, agent.Name, err)
+			}
+			return nil
+		}
+	}
+
+	log.Warn().Str("agent", agent.Name).Str("provider", p.name).Msg("device not found, skipping removal")
+	return nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	poolTag := fmt.Sprintf("%s=%s", engine.LabelPool, p.config.PoolID)
+	devices, err := p.client.FindProjectDevicesByTag(ctx, p.projectID, poolTag)
+	if err != nil {
+		return nil, fmt.Errorf("%s: FindProjectDevicesByTag: %w", p.name, err)
+	}
+
+	names := make([]string, 0, len(devices))
+	for _, d := range devices {
+		names = append(names, d.GetHostname())
+	}
+	return names, nil
+}

--- a/providers/equinixmetal/provider_test.go
+++ b/providers/equinixmetal/provider_test.go
@@ -1,0 +1,173 @@
+package equinixmetal
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/equinix/equinix-sdk-go/services/metalv1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+// mockDevicesAPI implements DevicesAPI for unit tests.
+type mockDevicesAPI struct {
+	mock.Mock
+}
+
+func (m *mockDevicesAPI) CreateDevice(ctx context.Context, projectID string, body metalv1.CreateDeviceRequest) (*metalv1.Device, error) {
+	args := m.Called(ctx, projectID, body)
+	if d := args.Get(0); d != nil {
+		return d.(*metalv1.Device), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockDevicesAPI) DeleteDevice(ctx context.Context, deviceID string) error {
+	return m.Called(ctx, deviceID).Error(0)
+}
+
+func (m *mockDevicesAPI) FindProjectDevicesByTag(ctx context.Context, projectID string, tag string) ([]metalv1.Device, error) {
+	args := m.Called(ctx, projectID, tag)
+	if d := args.Get(0); d != nil {
+		return d.([]metalv1.Device), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+const (
+	testProjectID = "proj-abc-123"
+	testPoolID    = "pool-1"
+)
+
+func testProvider(client DevicesAPI) *Provider {
+	return &Provider{
+		name:      "equinixmetal",
+		projectID: testProjectID,
+		metro:     "sv",
+		plan:      "c3.small.x86",
+		os:        "ubuntu_22_04",
+		labels: map[string]string{
+			engine.LabelPool:  testPoolID,
+			engine.LabelImage: "ubuntu_22_04",
+		},
+		config: &config.Config{
+			PoolID:            testPoolID,
+			GRPCAddress:       "grpc.example.com:9000",
+			WorkflowsPerAgent: 2,
+		},
+		client: client,
+	}
+}
+
+func poolTag() string {
+	return fmt.Sprintf("%s=%s", engine.LabelPool, testPoolID)
+}
+
+func TestDeployAgent(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+	agent := &woodpecker.Agent{Name: "wp-agent-1", Token: "test-token"}
+
+	m.On("CreateDevice", mock.Anything, testProjectID,
+		mock.MatchedBy(func(b metalv1.CreateDeviceRequest) bool {
+			in := b.DeviceCreateInMetroInput
+			return in != nil && in.GetHostname() == agent.Name && in.GetMetro() == "sv"
+		}),
+	).Return(&metalv1.Device{}, nil)
+
+	err := p.DeployAgent(context.Background(), agent)
+	assert.NoError(t, err)
+	m.AssertExpectations(t)
+}
+
+func TestDeployAgent_APIError(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+	agent := &woodpecker.Agent{Name: "wp-agent-fail", Token: "test-token"}
+
+	m.On("CreateDevice", mock.Anything, testProjectID, mock.Anything).
+		Return(nil, fmt.Errorf("quota exceeded"))
+
+	err := p.DeployAgent(context.Background(), agent)
+	assert.ErrorContains(t, err, "CreateDevice")
+	assert.ErrorContains(t, err, "quota exceeded")
+	m.AssertExpectations(t)
+}
+
+func TestRemoveAgent(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+
+	deviceID := "device-xyz-456"
+	d := metalv1.Device{}
+	d.SetHostname("wp-agent-1")
+	d.SetId(deviceID)
+
+	m.On("FindProjectDevicesByTag", mock.Anything, testProjectID, poolTag()).
+		Return([]metalv1.Device{d}, nil)
+	m.On("DeleteDevice", mock.Anything, deviceID).Return(nil)
+
+	err := p.RemoveAgent(context.Background(), &woodpecker.Agent{Name: "wp-agent-1"})
+	assert.NoError(t, err)
+	m.AssertExpectations(t)
+}
+
+func TestRemoveAgent_NotFound(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+
+	m.On("FindProjectDevicesByTag", mock.Anything, testProjectID, poolTag()).
+		Return([]metalv1.Device{}, nil)
+
+	err := p.RemoveAgent(context.Background(), &woodpecker.Agent{Name: "wp-agent-missing"})
+	assert.NoError(t, err)
+	m.AssertNotCalled(t, "DeleteDevice", mock.Anything, mock.Anything)
+	m.AssertExpectations(t)
+}
+
+func TestRemoveAgent_ListError(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+
+	m.On("FindProjectDevicesByTag", mock.Anything, testProjectID, poolTag()).
+		Return(nil, fmt.Errorf("network error"))
+
+	err := p.RemoveAgent(context.Background(), &woodpecker.Agent{Name: "wp-agent-1"})
+	assert.ErrorContains(t, err, "FindProjectDevicesByTag")
+	m.AssertExpectations(t)
+}
+
+func TestListDeployedAgentNames(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+
+	d1, d2 := metalv1.Device{}, metalv1.Device{}
+	d1.SetHostname("wp-agent-1")
+	d2.SetHostname("wp-agent-2")
+
+	m.On("FindProjectDevicesByTag", mock.Anything, testProjectID, poolTag()).
+		Return([]metalv1.Device{d1, d2}, nil)
+
+	names, err := p.ListDeployedAgentNames(context.Background())
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{"wp-agent-1", "wp-agent-2"}, names)
+	m.AssertExpectations(t)
+}
+
+func TestListDeployedAgentNames_Empty(t *testing.T) {
+	m := &mockDevicesAPI{}
+	p := testProvider(m)
+
+	m.On("FindProjectDevicesByTag", mock.Anything, testProjectID, poolTag()).
+		Return([]metalv1.Device{}, nil)
+
+	names, err := p.ListDeployedAgentNames(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, names)
+	m.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

Implements the Equinix Metal cloud provider, closing #104.

- Uses the official `github.com/equinix/equinix-sdk-go` SDK (`metalv1` package) — no legacy `packngo` dependency
- Introduces a `DevicesAPI` interface so the provider is fully testable without a real API token
- All three `Provider` methods covered by unit tests using `testify/mock`
- Handles pagination via `ExecuteWithPagination()` to correctly list all devices in large pools
- Validates required flags (`api-token`, `project-id`) at startup with clear error messages

## Configuration

| Flag | Env var | Default | Description |
|---|---|---|---|
| `--equinixmetal-api-token` | `WOODPECKER_EQUINIXMETAL_API_TOKEN` | — | API token |
| `--equinixmetal-project-id` | `WOODPECKER_EQUINIXMETAL_PROJECT_ID` | — | Project ID |
| `--equinixmetal-metro` | `WOODPECKER_EQUINIXMETAL_METRO` | `sv` | Metro code (sv, da, ny, am, …) |
| `--equinixmetal-plan` | `WOODPECKER_EQUINIXMETAL_PLAN` | `c3.small.x86` | Server plan |
| `--equinixmetal-os` | `WOODPECKER_EQUINIXMETAL_OS` | `ubuntu_22_04` | OS slug |
| `--equinixmetal-ssh-keys` | `WOODPECKER_EQUINIXMETAL_SSH_KEYS` | — | SSH key IDs |
| `--equinixmetal-tags` | `WOODPECKER_EQUINIXMETAL_TAGS` | — | Extra tags (`key=value`) |

## Test plan

- [x] Unit tests pass (`go test ./providers/equinixmetal/...` — 7 tests)
- [x] Full test suite passes with no regressions
- [x] `go vet ./...` clean
- [x] `go build ./...` clean