### PR TITLE
feat: Add Oracle Cloud Infrastructure (OCI) Provider Scaffold

### DIFF
--- a/engine/provider/factory.go
+++ b/engine/provider/factory.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/woodpecker-ci/woodpecker/woodpecker-go/woodpecker"
+
+	"github.com/woodpecker-ci/autoscaler/engine/provider/oracle"
+	"github.com/woodpecker-ci/autoscaler/engine/types"
+)
+
+func New(client woodpecker.Client, providerName, providerConfig string, poolID int) (types.Provider, error) {
+	var p types.Provider
+
+	switch providerName {
+	case oracle.Name:
+		var config oracle.Provider
+		if err := json.Unmarshal([]byte(providerConfig), &config); err != nil {
+			return nil, err
+		}
+		p = &config
+	default:
+		return nil, fmt.Errorf("provider '%s' not supported", providerName)
+	}
+
+	return p, nil
+}

--- a/engine/provider/oracle/oracle.go
+++ b/engine/provider/oracle/oracle.go
@@ -1,0 +1,59 @@
+// Copyright 2023 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/woodpecker-ci/autoscaler/engine/types"
+)
+
+const Name = "oracle"
+
+type Provider struct {
+	Image          string `json:"image"`
+	Region         string `json:"region"`
+	Tenancy        string `json:"tenancy"`
+	Compartment    string `json:"compartment"`
+	User           string `json:"user"`
+	Key            string `json:"key"`
+	Fingerprint    string `json:"fingerprint"`
+	Subnet         string `json:"subnet"`
+	Vcn            string `json:"vcn"`
+	SecurityGroup  string `json:"security_group"`
+	Shape          string `json:"shape"`
+	AuthorisedKeys string `json:"authorised_keys"`
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *types.Agent) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (p *Provider) getAgents(ctx context.Context) ([]*types.Agent, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (p *Provider) GetAgent(ctx context.Context, agentID string) (*types.Agent, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *types.Agent) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (p *Provider) ListAgents(ctx context.Context) ([]*types.Agent, error) {
+	return nil, fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
Resolves #102. Scaffolded the initial provider logic for Oracle Cloud Infrastructure (OCI). Registered the Oracle provider in the factory and implemented the core structural interfaces required by the Autoscaler engine.