### PR TITLE
Add DigitalOcean autoscaler provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The agents will use `WOODPECKER_GRPC_ADDR` and a token automatically generated b
   - [x] Amazon AWS
   - [ ] Google Cloud
   - [ ] Azure
-  - [ ] Digital Ocean
+  - [x] Digital Ocean
   - [x] Linode (temp disabled until the [security issue](https://github.com/woodpecker-ci/autoscaler/issues/91) was addressed)
   - [ ] Oracle Cloud
   - [ ] Equinix Metal

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -16,6 +16,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/engine/types"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/digitalocean"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
 	"go.woodpecker-ci.org/autoscaler/providers/vultr"
@@ -27,6 +28,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	switch cmd.String("provider") {
 	case "aws":
 		return aws.New(ctx, cmd, config)
+	case "digitalocean":
+		return digitalocean.New(ctx, cmd, config)
 	case "hetznercloud":
 		return hetznercloud.New(ctx, cmd, config)
 	// TODO: Temp disabled due to the security issue https://github.com/woodpecker-ci/autoscaler/issues/91
@@ -168,6 +171,7 @@ func main() {
 	// Enable it again when the issue is fixed.
 	// app.Flags = append(app.Flags, linode.ProviderFlags...)
 	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, digitalocean.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.302.0
+	github.com/digitalocean/godo v1.184.0
 	github.com/docker/go-units v0.5.0
 	github.com/hetznercloud/hcloud-go/v2 v2.40.0
 	github.com/joho/godotenv v1.5.1
@@ -53,8 +54,10 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/godo v1.184.0 h1:2B2CQhxftlf3xa24Nrzn5CBQlaQjyaWqi3XbbnJlG3w=
+github.com/digitalocean/godo v1.184.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
@@ -114,6 +116,8 @@ go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
 go.yaml.in/yaml/v4 v4.0.0-rc.3 h1:3h1fjsh1CTAPjW7q/EMe+C8shx5d8ctzZTrLcs/j8Go=
 go.yaml.in/yaml/v4 v4.0.0-rc.3/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a h1:+3jdDGGB8NGb1Zktc737jlt3/A5f6UlwSzmvqUuufxw=
 golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a/go.mod h1:d2fgXJLVs4dYDHUk5lwMIfzRzSrWCfGZb0ZqeLa/Vcw=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=

--- a/providers/digitalocean/flags.go
+++ b/providers/digitalocean/flags.go
@@ -1,0 +1,66 @@
+package digitalocean
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "DigitalOcean"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "digitalocean-api-token",
+		Usage: "DigitalOcean API token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-region",
+		Value:    "nyc1",
+		Usage:    "DigitalOcean region slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-size",
+		Value:    "s-1vcpu-1gb",
+		Usage:    "DigitalOcean droplet size slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SIZE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-image",
+		Value:    "ubuntu-22-04-x64",
+		Usage:    "DigitalOcean image slug",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IMAGE"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-ssh-keys",
+		Usage:    "DigitalOcean SSH key fingerprints or IDs",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SSH_KEYS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-tags",
+		Usage:    "DigitalOcean droplet tags",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_TAGS"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-ipv6",
+		Usage:    "Enable IPv6 for DigitalOcean droplets",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IPV6"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-vpc-uuid",
+		Usage:    "DigitalOcean VPC UUID",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_VPC_UUID"),
+		Category: category,
+	},
+}

--- a/providers/digitalocean/provider.go
+++ b/providers/digitalocean/provider.go
@@ -1,0 +1,459 @@
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/digitalocean/godo"
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine/inits/cloudinit"
+	"go.woodpecker-ci.org/autoscaler/engine/types"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+var (
+	ErrParameterNotSet          = errors.New("required parameter not set")
+	ErrImageNotFound            = errors.New("image not found")
+	ErrImageUnavailableInRegion = errors.New("image unavailable in region")
+	ErrInvalidTag               = errors.New("invalid tag")
+	ErrRegionNotFound           = errors.New("region not found")
+	ErrRegionUnavailable        = errors.New("region unavailable")
+	ErrSSHKeyNotFound           = errors.New("SSH key not found")
+	ErrSizeNotFound             = errors.New("size not found")
+	ErrSizeUnavailable          = errors.New("size unavailable")
+	ErrSizeUnavailableInRegion  = errors.New("size unavailable in region")
+)
+
+type dropletsService interface {
+	Create(context.Context, *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error)
+	Delete(context.Context, int) (*godo.Response, error)
+	ListByTag(context.Context, string, *godo.ListOptions) ([]godo.Droplet, *godo.Response, error)
+}
+
+type imagesService interface {
+	GetBySlug(context.Context, string) (*godo.Image, *godo.Response, error)
+}
+
+type keysService interface {
+	List(context.Context, *godo.ListOptions) ([]godo.Key, *godo.Response, error)
+}
+
+type regionsService interface {
+	List(context.Context, *godo.ListOptions) ([]godo.Region, *godo.Response, error)
+}
+
+type sizesService interface {
+	List(context.Context, *godo.ListOptions) ([]godo.Size, *godo.Response, error)
+}
+
+type Provider struct {
+	name       string
+	region     string
+	size       string
+	image      string
+	sshKeys    []godo.DropletCreateSSHKey
+	tags       []string
+	poolTag    string
+	enableIPv6 bool
+	vpcUUID    string
+	config     *config.Config
+	droplets   dropletsService
+	images     imagesService
+	keys       keysService
+	regions    regionsService
+	sizes      sizesService
+}
+
+func New(ctx context.Context, c *cli.Command, config *config.Config) (types.Provider, error) {
+	token := strings.TrimSpace(c.String("digitalocean-api-token"))
+	if token == "" {
+		return nil, fmt.Errorf("%w: digitalocean-api-token", ErrParameterNotSet)
+	}
+
+	client := godo.NewFromToken(token)
+	p := &Provider{
+		name:       "digitalocean",
+		region:     c.String("digitalocean-region"),
+		size:       c.String("digitalocean-size"),
+		image:      c.String("digitalocean-image"),
+		enableIPv6: c.Bool("digitalocean-ipv6"),
+		vpcUUID:    c.String("digitalocean-vpc-uuid"),
+		config:     config,
+		droplets:   client.Droplets,
+		images:     client.Images,
+		keys:       client.Keys,
+		regions:    client.Regions,
+		sizes:      client.Sizes,
+	}
+
+	p.poolTag = buildInternalTag("pool", config.PoolID)
+	p.tags = []string{
+		p.poolTag,
+		buildInternalTag("image", p.image),
+	}
+
+	for _, tag := range c.StringSlice("digitalocean-tags") {
+		tag = strings.TrimSpace(tag)
+		if !validTag(tag) {
+			return nil, fmt.Errorf("%s: %w: %s", p.name, ErrInvalidTag, tag)
+		}
+		p.tags = append(p.tags, tag)
+	}
+
+	if err := p.resolveConfig(ctx, c.StringSlice("digitalocean-ssh-keys")); err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+func (p *Provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := cloudinit.RenderUserDataTemplate(p.config, agent, nil)
+	if err != nil {
+		return fmt.Errorf("%s: cloudinit.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	createReq := &godo.DropletCreateRequest{
+		Name:     agent.Name,
+		Region:   p.region,
+		Size:     p.size,
+		UserData: userData,
+		SSHKeys:  p.sshKeys,
+		Tags:     p.tags,
+		IPv6:     p.enableIPv6,
+		Image: godo.DropletCreateImage{
+			Slug: p.image,
+		},
+	}
+	if p.vpcUUID != "" {
+		createReq.VPCUUID = p.vpcUUID
+	}
+
+	log.Info().Msgf("create agent: region = %s size = %s", p.region, p.size)
+
+	if _, _, err = p.droplets.Create(ctx, createReq); err != nil {
+		return fmt.Errorf("%s: Droplets.Create: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	droplet, err := p.findDropletByName(ctx, agent.Name)
+	if err != nil {
+		return fmt.Errorf("%s: findDropletByName: %w", p.name, err)
+	}
+
+	if droplet == nil {
+		return nil
+	}
+
+	if _, err = p.droplets.Delete(ctx, droplet.ID); err != nil {
+		return fmt.Errorf("%s: Droplets.Delete: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *Provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	droplets, err := p.listDropletsByPool(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s: Droplets.ListByTag: %w", p.name, err)
+	}
+
+	names := make([]string, 0, len(droplets))
+	for _, droplet := range droplets {
+		names = append(names, droplet.Name)
+	}
+
+	return names, nil
+}
+
+func (p *Provider) findDropletByName(ctx context.Context, name string) (*godo.Droplet, error) {
+	droplets, err := p.listDropletsByPool(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var found *godo.Droplet
+	for i := range droplets {
+		if droplets[i].Name != name {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("found multiple droplets with name %s", name)
+		}
+		found = &droplets[i]
+	}
+
+	return found, nil
+}
+
+func (p *Provider) listDropletsByPool(ctx context.Context) ([]godo.Droplet, error) {
+	var droplets []godo.Droplet
+
+	page := 1
+	for {
+		list, resp, err := p.droplets.ListByTag(ctx, p.poolTag, &godo.ListOptions{
+			Page:    page,
+			PerPage: 200, //nolint:mnd
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		droplets = append(droplets, list...)
+		if !hasNextPage(resp) {
+			return droplets, nil
+		}
+		page++
+	}
+}
+
+func (p *Provider) resolveConfig(ctx context.Context, rawSSHKeys []string) error {
+	if strings.TrimSpace(p.region) == "" {
+		return fmt.Errorf("%w: digitalocean-region", ErrParameterNotSet)
+	}
+	if strings.TrimSpace(p.size) == "" {
+		return fmt.Errorf("%w: digitalocean-size", ErrParameterNotSet)
+	}
+	if strings.TrimSpace(p.image) == "" {
+		return fmt.Errorf("%w: digitalocean-image", ErrParameterNotSet)
+	}
+
+	region, err := p.resolveRegion(ctx)
+	if err != nil {
+		return err
+	}
+
+	size, err := p.resolveSize(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !contains(region.Sizes, p.size) || !contains(size.Regions, p.region) {
+		return fmt.Errorf("%s: %w: %s in %s", p.name, ErrSizeUnavailableInRegion, p.size, p.region)
+	}
+
+	image, _, err := p.images.GetBySlug(ctx, p.image)
+	if err != nil {
+		return fmt.Errorf("%s: Images.GetBySlug: %w", p.name, err)
+	}
+	if image == nil {
+		return fmt.Errorf("%s: %w: %s", p.name, ErrImageNotFound, p.image)
+	}
+	if len(image.Regions) > 0 && !contains(image.Regions, p.region) {
+		return fmt.Errorf("%s: %w: %s in %s", p.name, ErrImageUnavailableInRegion, p.image, p.region)
+	}
+
+	sshKeys, err := p.resolveSSHKeys(ctx, rawSSHKeys)
+	if err != nil {
+		return err
+	}
+	p.sshKeys = sshKeys
+
+	return nil
+}
+
+func (p *Provider) resolveRegion(ctx context.Context) (*godo.Region, error) {
+	page := 1
+	for {
+		regions, resp, err := p.regions.List(ctx, &godo.ListOptions{Page: page, PerPage: 200}) //nolint:mnd
+		if err != nil {
+			return nil, fmt.Errorf("%s: Regions.List: %w", p.name, err)
+		}
+
+		for i := range regions {
+			if regions[i].Slug != p.region {
+				continue
+			}
+			if !regions[i].Available {
+				return nil, fmt.Errorf("%s: %w: %s", p.name, ErrRegionUnavailable, p.region)
+			}
+			return &regions[i], nil
+		}
+
+		if !hasNextPage(resp) {
+			return nil, fmt.Errorf("%s: %w: %s", p.name, ErrRegionNotFound, p.region)
+		}
+		page++
+	}
+}
+
+func (p *Provider) resolveSize(ctx context.Context) (*godo.Size, error) {
+	page := 1
+	for {
+		sizes, resp, err := p.sizes.List(ctx, &godo.ListOptions{Page: page, PerPage: 200}) //nolint:mnd
+		if err != nil {
+			return nil, fmt.Errorf("%s: Sizes.List: %w", p.name, err)
+		}
+
+		for i := range sizes {
+			if sizes[i].Slug != p.size {
+				continue
+			}
+			if !sizes[i].Available {
+				return nil, fmt.Errorf("%s: %w: %s", p.name, ErrSizeUnavailable, p.size)
+			}
+			return &sizes[i], nil
+		}
+
+		if !hasNextPage(resp) {
+			return nil, fmt.Errorf("%s: %w: %s", p.name, ErrSizeNotFound, p.size)
+		}
+		page++
+	}
+}
+
+func (p *Provider) resolveSSHKeys(ctx context.Context, rawKeys []string) ([]godo.DropletCreateSSHKey, error) {
+	keys, err := p.listSSHKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("%s: %w", p.name, ErrSSHKeyNotFound)
+	}
+
+	byName := make(map[string]godo.Key, len(keys))
+	byFingerprint := make(map[string]godo.Key, len(keys))
+	byID := make(map[string]godo.Key, len(keys))
+	for _, key := range keys {
+		byName[key.Name] = key
+		byFingerprint[key.Fingerprint] = key
+		byID[strconv.Itoa(key.ID)] = key
+	}
+
+	if len(rawKeys) == 0 {
+		for _, name := range []string{"woodpecker", "id_rsa_woodpecker"} {
+			key, ok := byName[name]
+			if ok {
+				return []godo.DropletCreateSSHKey{dropletSSHKey(key)}, nil
+			}
+		}
+		return []godo.DropletCreateSSHKey{dropletSSHKey(keys[0])}, nil
+	}
+
+	resolved := make([]godo.DropletCreateSSHKey, 0, len(rawKeys))
+	for _, raw := range rawKeys {
+		raw = strings.TrimSpace(raw)
+		key, ok := byFingerprint[raw]
+		if !ok {
+			key, ok = byID[raw]
+		}
+		if !ok {
+			return nil, fmt.Errorf("%s: %w: %s", p.name, ErrSSHKeyNotFound, raw)
+		}
+		resolved = append(resolved, dropletSSHKey(key))
+	}
+
+	return resolved, nil
+}
+
+func (p *Provider) listSSHKeys(ctx context.Context) ([]godo.Key, error) {
+	var keys []godo.Key
+
+	page := 1
+	for {
+		list, resp, err := p.keys.List(ctx, &godo.ListOptions{Page: page, PerPage: 200}) //nolint:mnd
+		if err != nil {
+			return nil, fmt.Errorf("%s: Keys.List: %w", p.name, err)
+		}
+
+		keys = append(keys, list...)
+		if !hasNextPage(resp) {
+			return keys, nil
+		}
+		page++
+	}
+}
+
+func dropletSSHKey(key godo.Key) godo.DropletCreateSSHKey {
+	if key.ID != 0 {
+		return godo.DropletCreateSSHKey{ID: key.ID}
+	}
+
+	return godo.DropletCreateSSHKey{Fingerprint: key.Fingerprint}
+}
+
+func buildInternalTag(kind, value string) string {
+	value = sanitizeTagValue(value)
+	if value == "" {
+		value = "default"
+	}
+
+	tag := "wp-autoscaler-" + kind + "-" + value
+	if len(tag) > 255 {
+		return tag[:255]
+	}
+
+	return tag
+}
+
+func sanitizeTagValue(value string) string {
+	value = strings.TrimSpace(value)
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			lastDash = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+			lastDash = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		case r == ':' || r == '-' || r == '_':
+			b.WriteRune(r)
+			lastDash = false
+		default:
+			if !lastDash {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
+}
+
+func validTag(tag string) bool {
+	if tag == "" || len(tag) > 255 {
+		return false
+	}
+
+	for _, r := range tag {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == ':' || r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+
+	return true
+}
+
+func contains(list []string, item string) bool {
+	for _, elem := range list {
+		if elem == item {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNextPage(resp *godo.Response) bool {
+	return resp != nil && resp.Links != nil && resp.Links.Pages != nil && resp.Links.Pages.Next != ""
+}
+
+var _ types.Provider = (*Provider)(nil)

--- a/providers/digitalocean/provider_test.go
+++ b/providers/digitalocean/provider_test.go
@@ -1,0 +1,197 @@
+package digitalocean
+
+import (
+	"context"
+	"testing"
+
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+type fakeDroplets struct {
+	createReq *godo.DropletCreateRequest
+	deletedID int
+	pages     [][]godo.Droplet
+}
+
+func (f *fakeDroplets) Create(_ context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
+	f.createReq = req
+	return &godo.Droplet{ID: 42}, nil, nil
+}
+
+func (f *fakeDroplets) Delete(_ context.Context, dropletID int) (*godo.Response, error) {
+	f.deletedID = dropletID
+	return nil, nil
+}
+
+func (f *fakeDroplets) ListByTag(_ context.Context, _ string, opt *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
+	page := opt.Page - 1
+	if page < 0 || page >= len(f.pages) {
+		return nil, nil, nil
+	}
+
+	return f.pages[page], responseWithNext(page < len(f.pages)-1), nil
+}
+
+type fakeKeys struct {
+	keys []godo.Key
+}
+
+func (f fakeKeys) List(_ context.Context, _ *godo.ListOptions) ([]godo.Key, *godo.Response, error) {
+	return f.keys, nil, nil
+}
+
+type fakeImages struct {
+	image *godo.Image
+}
+
+func (f fakeImages) GetBySlug(_ context.Context, _ string) (*godo.Image, *godo.Response, error) {
+	return f.image, nil, nil
+}
+
+type fakeRegions struct {
+	regions []godo.Region
+}
+
+func (f fakeRegions) List(_ context.Context, _ *godo.ListOptions) ([]godo.Region, *godo.Response, error) {
+	return f.regions, nil, nil
+}
+
+type fakeSizes struct {
+	sizes []godo.Size
+}
+
+func (f fakeSizes) List(_ context.Context, _ *godo.ListOptions) ([]godo.Size, *godo.Response, error) {
+	return f.sizes, nil, nil
+}
+
+func TestDeployAgentBuildsDropletRequest(t *testing.T) {
+	droplets := &fakeDroplets{}
+	provider := &Provider{
+		name:       "digitalocean",
+		region:     "nyc1",
+		size:       "s-1vcpu-1gb",
+		image:      "ubuntu-22-04-x64",
+		tags:       []string{"wp-autoscaler-pool-main", "custom-tag"},
+		sshKeys:    []godo.DropletCreateSSHKey{{ID: 123}},
+		enableIPv6: true,
+		vpcUUID:    "vpc-uuid",
+		config: &config.Config{
+			Image:             "woodpeckerci/woodpecker-agent:next",
+			GRPCAddress:       "grpc.example.com",
+			GRPCSecure:        true,
+			WorkflowsPerAgent: 2,
+		},
+		droplets: droplets,
+	}
+
+	err := provider.DeployAgent(t.Context(), &woodpecker.Agent{Name: "agent-1", Token: "secret"})
+	require.NoError(t, err)
+	require.NotNil(t, droplets.createReq)
+
+	assert.Equal(t, "agent-1", droplets.createReq.Name)
+	assert.Equal(t, "nyc1", droplets.createReq.Region)
+	assert.Equal(t, "s-1vcpu-1gb", droplets.createReq.Size)
+	assert.Equal(t, "ubuntu-22-04-x64", droplets.createReq.Image.Slug)
+	assert.Equal(t, []string{"wp-autoscaler-pool-main", "custom-tag"}, droplets.createReq.Tags)
+	assert.Equal(t, []godo.DropletCreateSSHKey{{ID: 123}}, droplets.createReq.SSHKeys)
+	assert.True(t, droplets.createReq.IPv6)
+	assert.Equal(t, "vpc-uuid", droplets.createReq.VPCUUID)
+	assert.Contains(t, droplets.createReq.UserData, "WOODPECKER_AGENT_SECRET=secret")
+}
+
+func TestRemoveAgentDeletesOnlyPoolDroplet(t *testing.T) {
+	droplets := &fakeDroplets{
+		pages: [][]godo.Droplet{
+			{
+				{ID: 7, Name: "agent-1"},
+				{ID: 8, Name: "agent-2"},
+			},
+		},
+	}
+	provider := &Provider{name: "digitalocean", poolTag: "wp-autoscaler-pool-main", droplets: droplets}
+
+	err := provider.RemoveAgent(t.Context(), &woodpecker.Agent{Name: "agent-2"})
+	require.NoError(t, err)
+	assert.Equal(t, 8, droplets.deletedID)
+}
+
+func TestListDeployedAgentNamesUsesPoolTagPagination(t *testing.T) {
+	provider := &Provider{
+		name:    "digitalocean",
+		poolTag: "wp-autoscaler-pool-main",
+		droplets: &fakeDroplets{
+			pages: [][]godo.Droplet{
+				{{Name: "agent-1"}},
+				{{Name: "agent-2"}},
+			},
+		},
+	}
+
+	names, err := provider.ListDeployedAgentNames(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"agent-1", "agent-2"}, names)
+}
+
+func TestResolveSSHKeys(t *testing.T) {
+	provider := &Provider{
+		name: "digitalocean",
+		keys: fakeKeys{keys: []godo.Key{
+			{ID: 123, Name: "woodpecker", Fingerprint: "fingerprint-123"},
+			{ID: 456, Name: "other", Fingerprint: "fingerprint-456"},
+		}},
+	}
+
+	keys, err := provider.resolveSSHKeys(t.Context(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, []godo.DropletCreateSSHKey{{ID: 123}}, keys)
+
+	keys, err = provider.resolveSSHKeys(t.Context(), []string{"fingerprint-456"})
+	require.NoError(t, err)
+	assert.Equal(t, []godo.DropletCreateSSHKey{{ID: 456}}, keys)
+}
+
+func TestResolveConfigValidatesImageRegion(t *testing.T) {
+	provider := &Provider{
+		name:   "digitalocean",
+		region: "nyc1",
+		size:   "s-1vcpu-1gb",
+		image:  "ubuntu-22-04-x64",
+		regions: fakeRegions{regions: []godo.Region{
+			{Slug: "nyc1", Available: true, Sizes: []string{"s-1vcpu-1gb"}},
+		}},
+		sizes: fakeSizes{sizes: []godo.Size{
+			{Slug: "s-1vcpu-1gb", Available: true, Regions: []string{"nyc1"}},
+		}},
+		images: fakeImages{image: &godo.Image{Slug: "ubuntu-22-04-x64", Regions: []string{"sfo3"}}},
+		keys: fakeKeys{keys: []godo.Key{
+			{ID: 123, Name: "woodpecker", Fingerprint: "fingerprint-123"},
+		}},
+	}
+
+	err := provider.resolveConfig(t.Context(), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ErrImageUnavailableInRegion.Error())
+}
+
+func TestDigitalOceanTags(t *testing.T) {
+	assert.True(t, validTag("letters:digits-123_under"))
+	assert.False(t, validTag("wp.autoscaler/pool=main"))
+	assert.Equal(t, "wp-autoscaler-pool-main-default", buildInternalTag("pool", "main/default"))
+}
+
+func responseWithNext(next bool) *godo.Response {
+	if !next {
+		return nil
+	}
+
+	return &godo.Response{
+		Links: &godo.Links{
+			Pages: &godo.Pages{Next: "next"},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- add a DigitalOcean provider with CLI/env configuration flags
- resolve provider configuration on startup, including region, size, image region availability, and SSH keys
- use DigitalOcean-safe internal tags for pool/image ownership and list/remove droplets by pool tag
- wire the provider into the autoscaler binary and mark DigitalOcean complete in the roadmap

Closes #103.

## Tests

- `go test ./...`
