### PR TITLE
Remove "WOODPECKER_FILTER_LABELS", use WOODPECKER_AGENT_LABELS

### DIFF
--- a/cmd/woodpecker-autoscaler/flags.go
+++ b/cmd/woodpecker-autoscaler/flags.go
@@ -107,12 +107,6 @@ var flags = []cli.Flag{
 		Usage:   "additional agent environment variables as list with key=value pairs",
 		Sources: cli.EnvVars("WOODPECKER_AGENT_ENV"),
 	},
-	&cli.StringFlag{
-		Name:    "filter-labels",
-		Value:   "",
-		Usage:   "filter for specific tasks using labels",
-		Sources: cli.EnvVars("WOODPECKER_FILTER_LABELS"),
-	},
 	&cli.StringSliceFlag{
 		Name:    "agent-labels",
 		Usage:   "add additional labels the agent will report to the server. list with key=value pairs",

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -93,7 +93,6 @@ func run(ctx context.Context, cmd *cli.Command) error {
 		GRPCAddress:       cmd.String("grpc-addr"),
 		GRPCSecure:        cmd.Bool("grpc-secure"),
 		Image:             cmd.String("agent-image"),
-		FilterLabels:      cmd.String("filter-labels"),
 		UserData:          cmd.String("provider-user-data"),
 		ExtraAgentLabels:  agentLabels,
 		Environment:       agentEnvironment,

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,5 @@ type Config struct {
 	AgentInactivityTimeout time.Duration
 	AgentIdleTimeout       time.Duration
 	UserData               string
-	FilterLabels           string
 	ExtraAgentLabels       map[string]string
 }

--- a/engine/autoscaler.go
+++ b/engine/autoscaler.go
@@ -374,14 +374,3 @@ func (a *Autoscaler) Reconcile(ctx context.Context) error {
 
 	return nil
 }
-
-func countTasksByLabel(jobs []woodpecker.Task, labelKey, labelValue string) int {
-	count := 0
-	for _, job := range jobs {
-		val, exists := job.Labels[labelKey]
-		if exists && val == labelValue {
-			count++
-		}
-	}
-	return count
-}

--- a/engine/autoscaler.go
+++ b/engine/autoscaler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -302,19 +301,7 @@ func (a *Autoscaler) getQueueInfo(_ context.Context) (freeTasks, runningTasks, p
 		return 0, 0, 0, fmt.Errorf("error from QueueInfo: %s", err.Error())
 	}
 
-	if a.config.FilterLabels == "" {
-		return queueInfo.Stats.Workers, queueInfo.Stats.Running, queueInfo.Stats.Pending, nil
-	}
-
-	labelFilterKey, labelFilterValue, ok := strings.Cut(a.config.FilterLabels, "=")
-	if !ok {
-		return 0, 0, 0, fmt.Errorf("invalid labels filter: %s", a.config.FilterLabels)
-	}
-
-	running := countTasksByLabel(queueInfo.Running, labelFilterKey, labelFilterValue)
-	pending := countTasksByLabel(queueInfo.Pending, labelFilterKey, labelFilterValue)
-
-	return queueInfo.Stats.Workers, running, pending, nil
+	return queueInfo.Stats.Workers, queueInfo.Stats.Running, queueInfo.Stats.Pending, nil
 }
 
 func (a *Autoscaler) calcAgents(ctx context.Context) (float64, error) {

--- a/engine/autoscaler_test.go
+++ b/engine/autoscaler_test.go
@@ -131,38 +131,6 @@ func Test_getQueueInfo(t *testing.T) {
 		assert.Equal(t, 0, running)
 		assert.Equal(t, 2, pending)
 	})
-
-	t.Run("should filter one by label", func(t *testing.T) {
-		autoscaler := Autoscaler{
-			client: &MockClient{
-				pending: 2,
-			},
-			config: &config.Config{
-				FilterLabels: "arch=amd64",
-			},
-		}
-
-		free, running, pending, _ := autoscaler.getQueueInfo(t.Context())
-		assert.Equal(t, 0, free)
-		assert.Equal(t, 1, running)
-		assert.Equal(t, 1, pending)
-	})
-
-	t.Run("should filter all by label", func(t *testing.T) {
-		autoscaler := Autoscaler{
-			client: &MockClient{
-				pending: 2,
-			},
-			config: &config.Config{
-				FilterLabels: "arch=arm64",
-			},
-		}
-
-		free, running, pending, _ := autoscaler.getQueueInfo(t.Context())
-		assert.Equal(t, 0, free)
-		assert.Equal(t, 0, running)
-		assert.Equal(t, 0, pending)
-	})
 }
 
 func Test_getPoolAgents(t *testing.T) {


### PR DESCRIPTION
not here jet with this pull but ... with #581 we will calc what labels an agent will have based on platform, backend and WOODPECKER_AGENT_LABELS. based on that we will look into the queue tasks and see if we should deploy.

using filter_labels is just a hacky way to achive the same but it works not always, so with v2.0 we should just get rid of it.