### PR TITLE
check hetzner numeric, fallback to name+architecture lookup for system images

### DIFF
--- a/providers/hetznercloud/helper.go
+++ b/providers/hetznercloud/helper.go
@@ -31,9 +31,9 @@ func (p *provider) resolveServerConfigs(ctx context.Context, serverType []string
 			return err
 		}
 
-		image, _, err := p.client.Image().GetByNameAndArchitecture(ctx, rawImage, serverType.Architecture)
+		image, _, err := p.client.Image().GetForArchitecture(ctx, rawImage, serverType.Architecture)
 		if err != nil {
-			return fmt.Errorf("%s: Image.GetByNameAndArchitecture: %w", p.name, err)
+			return fmt.Errorf("%s: Image.GetForArchitecture: %w", p.name, err)
 		}
 		if image == nil {
 			return fmt.Errorf("%s: %w: %s", p.name, ErrImageNotFound, rawImage)


### PR DESCRIPTION
## Fix(hetznercloud): support snapshot and backup images by numeric ID

### Problem

`WOODPECKER_HETZNERCLOUD_IMAGE` cannot be set to a Hetzner snapshot or backup ID. The provider calls `GetByNameAndArchitecture()` which queries the Hetzner API using the image `name` field. Snapshots and backups always have `name = null` — only system and app images have a name. This means any numeric ID passed as the image value results in:

`image not found: <id>`

### Fix

Try `Get()` first, which resolves both numeric IDs (`GET /v1/images/{id}`) and named images. Fall back to `GetByNameAndArchitecture()` for named system/app images (e.g. `debian-13`), preserving existing behaviour.

## Use case

Users who build hardened/customised Hetzner snapshots with Packer and want the autoscaler to spin up agents from that snapshot rather than a base system image.
