### PR TITLE
Add DigitalOcean provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The agents will use `WOODPECKER_GRPC_ADDR` and a token automatically generated b
   - [x] Amazon AWS
   - [ ] Google Cloud
   - [ ] Azure
-  - [ ] Digital Ocean
+  - [x] Digital Ocean
   - [x] Linode (temp disabled until the [security issue](https://github.com/woodpecker-ci/autoscaler/issues/91) was addressed)
   - [ ] Oracle Cloud
   - [ ] Equinix Metal

--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -16,6 +16,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/engine/types"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/digitalocean"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/linode"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
@@ -28,6 +29,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	switch cmd.String("provider") {
 	case "aws":
 		return aws.New(ctx, cmd, config)
+	case "digitalocean":
+		return digitalocean.New(ctx, cmd, config)
 	case "hetznercloud":
 		return hetznercloud.New(ctx, cmd, config)
 	case "linode":
@@ -153,6 +156,7 @@ func main() {
 	app.Flags = append(app.Flags, scaleway.ProviderFlags...)
 	app.Flags = append(app.Flags, linode.ProviderFlags...)
 	app.Flags = append(app.Flags, aws.ProviderFlags...)
+	app.Flags = append(app.Flags, digitalocean.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.18
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.304.0
+	github.com/digitalocean/godo v1.192.0
 	github.com/docker/go-units v0.5.0
 	github.com/hetznercloud/hcloud-go/v2 v2.41.2
 	github.com/joho/godotenv v1.5.1
@@ -55,6 +56,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/ini.v1 v1.67.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/godo v1.192.0 h1:It3AcVa123/Eh/Ol+F9CXXBBlTsWyUIYe8yZhhFZ9Q4=
+github.com/digitalocean/godo v1.192.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/providers/digitalocean/flags.go
+++ b/providers/digitalocean/flags.go
@@ -1,0 +1,82 @@
+package digitalocean
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "DigitalOcean"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "digitalocean-api-token",
+		Usage: "DigitalOcean api token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_DIGITALOCEAN_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_DIGITALOCEAN_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-region",
+		Usage:    "DigitalOcean region slug",
+		Value:    "nyc1",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_REGION"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-size",
+		Usage:    "DigitalOcean droplet size slug",
+		Value:    "s-1vcpu-1gb",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SIZE"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "digitalocean-image",
+		Usage:    "DigitalOcean image slug",
+		Value:    "ubuntu-24-04-x64",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_IMAGE"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-ssh-keys",
+		Usage:    "DigitalOcean SSH key IDs or fingerprints",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_SSH_KEYS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "digitalocean-tags",
+		Usage:    "DigitalOcean droplet tags",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_TAGS"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-public-ipv6-enable",
+		Value:    true,
+		Usage:    "enables public ipv6 network for agents",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_PUBLIC_IPV6_ENABLE"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-private-networking-enable",
+		Value:    true,
+		Usage:    "enables private networking for agents",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_PRIVATE_NETWORKING_ENABLE"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-monitoring-enable",
+		Value:    false,
+		Usage:    "enables monitoring for agents",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_MONITORING_ENABLE"),
+		Category: category,
+	},
+	&cli.BoolFlag{
+		Name:     "digitalocean-backups-enable",
+		Value:    false,
+		Usage:    "enables backups for agents",
+		Sources:  cli.EnvVars("WOODPECKER_DIGITALOCEAN_BACKUPS_ENABLE"),
+		Category: category,
+	},
+}

--- a/providers/digitalocean/provider.go
+++ b/providers/digitalocean/provider.go
@@ -1,0 +1,250 @@
+package digitalocean
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/digitalocean/godo"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine/inits/cloudinit"
+	"go.woodpecker-ci.org/autoscaler/engine/types"
+	"go.woodpecker-ci.org/autoscaler/version"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+const (
+	autoscalerTag = "woodpecker-autoscaler"
+	maxTagLength  = 255
+)
+
+var ErrAPITokenNotSet = errors.New("no api token provided")
+
+// blackhole metadata service so running steps can not extract agent token from user-data
+var blackholeMetadataAPI = []string{
+	"ip -4 route add blackhole 169.254.169.254/32",
+}
+
+type provider struct {
+	name              string
+	config            *config.Config
+	client            *godo.Client
+	region            string
+	size              string
+	image             string
+	sshKeys           []godo.DropletCreateSSHKey
+	tags              []string
+	poolTag           string
+	enableIPv6        bool
+	privateNetworking bool
+	monitoring        bool
+	backups           bool
+}
+
+func New(_ context.Context, c *cli.Command, config *config.Config) (types.Provider, error) {
+	apiToken := c.String("digitalocean-api-token")
+	if apiToken == "" {
+		return nil, ErrAPITokenNotSet
+	}
+
+	p := &provider{
+		name:              "digitalocean",
+		config:            config,
+		client:            newClient(apiToken),
+		region:            c.String("digitalocean-region"),
+		size:              c.String("digitalocean-size"),
+		image:             c.String("digitalocean-image"),
+		sshKeys:           parseSSHKeys(c.StringSlice("digitalocean-ssh-keys")),
+		poolTag:           poolTag(config.PoolID),
+		enableIPv6:        c.Bool("digitalocean-public-ipv6-enable"),
+		privateNetworking: c.Bool("digitalocean-private-networking-enable"),
+		monitoring:        c.Bool("digitalocean-monitoring-enable"),
+		backups:           c.Bool("digitalocean-backups-enable"),
+	}
+
+	p.tags = append([]string{autoscalerTag, p.poolTag}, c.StringSlice("digitalocean-tags")...)
+
+	return p, nil
+}
+
+func (p *provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := cloudinit.RenderUserDataTemplate(p.config, agent, nil, cloudinit.RenderOption{
+		PreExec: blackholeMetadataAPI,
+	})
+	if err != nil {
+		return fmt.Errorf("%s: cloudinit.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	_, _, err = p.client.Droplets.Create(ctx, &godo.DropletCreateRequest{
+		Name:              agent.Name,
+		Region:            p.region,
+		Size:              p.size,
+		Image:             godo.DropletCreateImage{Slug: p.image},
+		SSHKeys:           p.sshKeys,
+		Backups:           p.backups,
+		IPv6:              p.enableIPv6,
+		PrivateNetworking: p.privateNetworking,
+		Monitoring:        p.monitoring,
+		UserData:          userData,
+		Tags:              p.tags,
+	})
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Create: %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *provider) getAgent(ctx context.Context, agent *woodpecker.Agent) (*godo.Droplet, error) {
+	droplets, err := p.listDroplets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var found *godo.Droplet
+	for i := range droplets {
+		if droplets[i].Name != agent.Name {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("%s: getAgent: found multiple droplets with name %s", p.name, agent.Name)
+		}
+		found = &droplets[i]
+	}
+
+	return found, nil
+}
+
+func (p *provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	droplet, err := p.getAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("%s: getAgent %w", p.name, err)
+	}
+
+	if droplet == nil {
+		return nil
+	}
+
+	_, err = p.client.Droplets.Delete(ctx, droplet.ID)
+	if err != nil {
+		return fmt.Errorf("%s: Droplets.Delete %w", p.name, err)
+	}
+
+	return nil
+}
+
+func (p *provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	var names []string
+
+	droplets, err := p.listDroplets(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, droplet := range droplets {
+		names = append(names, droplet.Name)
+	}
+
+	return names, nil
+}
+
+func (p *provider) listDroplets(ctx context.Context) ([]godo.Droplet, error) {
+	var droplets []godo.Droplet
+
+	opts := &godo.ListOptions{
+		PerPage: 200, //nolint:mnd
+	}
+
+	for {
+		newDroplets, resp, err := p.client.Droplets.ListByTag(ctx, p.poolTag, opts)
+		if err != nil {
+			return nil, fmt.Errorf("%s: Droplets.ListByTag %w", p.name, err)
+		}
+
+		droplets = append(droplets, newDroplets...)
+
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		currentPage, err := resp.Links.CurrentPage()
+		if err != nil {
+			return nil, fmt.Errorf("%s: Links.CurrentPage %w", p.name, err)
+		}
+		opts.Page = currentPage + 1
+	}
+
+	return droplets, nil
+}
+
+func parseSSHKeys(keys []string) []godo.DropletCreateSSHKey {
+	sshKeys := make([]godo.DropletCreateSSHKey, 0, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		id, err := strconv.Atoi(key)
+		if err == nil {
+			sshKeys = append(sshKeys, godo.DropletCreateSSHKey{ID: id})
+			continue
+		}
+		sshKeys = append(sshKeys, godo.DropletCreateSSHKey{Fingerprint: key})
+	}
+
+	return sshKeys
+}
+
+func poolTag(poolID string) string {
+	return trimTag(fmt.Sprintf("woodpecker-pool-%s", sanitizeTag(poolID)))
+}
+
+func sanitizeTag(value string) string {
+	value = strings.ToLower(value)
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == ':', r == '_':
+			builder.WriteRune(r)
+			lastDash = false
+		case unicode.IsSpace(r), r == '-', r == '/', r == '.':
+			if !lastDash {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		default:
+			if !lastDash {
+				builder.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+
+	tag := strings.Trim(builder.String(), "-")
+	if tag == "" {
+		return "default"
+	}
+
+	return trimTag(tag)
+}
+
+func trimTag(tag string) string {
+	if len(tag) <= maxTagLength {
+		return tag
+	}
+
+	return strings.TrimRight(tag[:maxTagLength], "-")
+}
+
+func newClient(apiToken string) *godo.Client {
+	client := godo.NewFromToken(apiToken)
+	client.UserAgent = "woodpecker-autoscaler/" + version.String() + " " + client.UserAgent
+
+	return client
+}

--- a/providers/digitalocean/provider_test.go
+++ b/providers/digitalocean/provider_test.go
@@ -1,0 +1,44 @@
+package digitalocean
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSSHKeys(t *testing.T) {
+	keys := parseSSHKeys([]string{"12345", " SHA256:fingerprint ", ""})
+
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	if keys[0].ID != 12345 {
+		t.Fatalf("expected numeric key to be parsed as ID, got %d", keys[0].ID)
+	}
+	if keys[1].Fingerprint != "SHA256:fingerprint" {
+		t.Fatalf("expected non-numeric key to be parsed as fingerprint, got %q", keys[1].Fingerprint)
+	}
+}
+
+func TestPoolTag(t *testing.T) {
+	tag := poolTag("Woodpecker Pool/1.Main")
+
+	if tag != "woodpecker-pool-woodpecker-pool-1-main" {
+		t.Fatalf("unexpected pool tag %q", tag)
+	}
+}
+
+func TestSanitizeTag(t *testing.T) {
+	tag := sanitizeTag("  Team A / Pool.Main  ")
+
+	if tag != "team-a-pool-main" {
+		t.Fatalf("unexpected sanitized tag %q", tag)
+	}
+}
+
+func TestTrimTag(t *testing.T) {
+	tag := trimTag(strings.Repeat("a", maxTagLength+1))
+
+	if len(tag) != maxTagLength {
+		t.Fatalf("expected tag length %d, got %d", maxTagLength, len(tag))
+	}
+}


### PR DESCRIPTION
Fixes #103.

## Summary
- adds a DigitalOcean provider backed by the official godo client
- creates, deletes, and lists agent droplets by autoscaler pool tag
- exposes DigitalOcean CLI/env flags and blocks the metadata endpoint before agent startup

## Testing
- go test ./...