### PR TITLE
feat: add Equinix Metal provider

### DIFF
--- a/cmd/woodpecker-autoscaler/main.go
+++ b/cmd/woodpecker-autoscaler/main.go
@@ -16,6 +16,7 @@ import (
 	"go.woodpecker-ci.org/autoscaler/engine"
 	"go.woodpecker-ci.org/autoscaler/engine/types"
 	"go.woodpecker-ci.org/autoscaler/providers/aws"
+	"go.woodpecker-ci.org/autoscaler/providers/equinixmetal"
 	"go.woodpecker-ci.org/autoscaler/providers/hetznercloud"
 	"go.woodpecker-ci.org/autoscaler/providers/linode"
 	"go.woodpecker-ci.org/autoscaler/providers/scaleway"
@@ -28,6 +29,8 @@ func setupProvider(ctx context.Context, cmd *cli.Command, config *config.Config)
 	switch cmd.String("provider") {
 	case "aws":
 		return aws.New(ctx, cmd, config)
+	case "equinixmetal":
+		return equinixmetal.New(ctx, cmd, config)
 	case "hetznercloud":
 		return hetznercloud.New(ctx, cmd, config)
 	case "linode":
@@ -154,6 +157,7 @@ func main() {
 	app.Flags = append(app.Flags, linode.ProviderFlags...)
 	app.Flags = append(app.Flags, aws.ProviderFlags...)
 	app.Flags = append(app.Flags, vultr.ProviderFlags...)
+	app.Flags = append(app.Flags, equinixmetal.ProviderFlags...)
 
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Error().Err(err).Msg("got error while try to run autoscaler")

--- a/providers/equinixmetal/flags.go
+++ b/providers/equinixmetal/flags.go
@@ -1,0 +1,54 @@
+package equinixmetal
+
+import (
+	"os"
+
+	"github.com/urfave/cli/v3"
+)
+
+const category = "Equinix Metal"
+
+var ProviderFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:  "equinixmetal-api-token",
+		Usage: "Equinix Metal API token",
+		Sources: cli.NewValueSourceChain(
+			cli.EnvVar("WOODPECKER_EQUINIXMETAL_API_TOKEN"),
+			cli.File(os.Getenv("WOODPECKER_EQUINIXMETAL_API_TOKEN_FILE")),
+		),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-project-id",
+		Usage:    "Equinix Metal project ID",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_PROJECT_ID"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-metro",
+		Value:    "da",
+		Usage:    "Equinix Metal metro (e.g. da, sv, ny, am)",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_METRO"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-plan",
+		Value:    "c3.small.x86",
+		Usage:    "Equinix Metal device plan (e.g. c3.small.x86, m3.small.x86)",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_PLAN"),
+		Category: category,
+	},
+	&cli.StringFlag{
+		Name:     "equinixmetal-os",
+		Value:    "ubuntu_22_04",
+		Usage:    "Equinix Metal operating system slug",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_OS"),
+		Category: category,
+	},
+	&cli.StringSliceFlag{
+		Name:     "equinixmetal-tags",
+		Usage:    "Equinix Metal device tags",
+		Sources:  cli.EnvVars("WOODPECKER_EQUINIXMETAL_TAGS"),
+		Category: category,
+	},
+}

--- a/providers/equinixmetal/provider.go
+++ b/providers/equinixmetal/provider.go
@@ -1,0 +1,204 @@
+package equinixmetal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"github.com/urfave/cli/v3"
+
+	"go.woodpecker-ci.org/autoscaler/config"
+	"go.woodpecker-ci.org/autoscaler/engine/inits/cloudinit"
+	"go.woodpecker-ci.org/autoscaler/engine/types"
+	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
+)
+
+const apiBase = "https://api.equinix.com/metal/v1"
+
+type provider struct {
+	name      string
+	config    *config.Config
+	apiToken  string
+	projectID string
+	metro     string
+	plan      string
+	os        string
+	tags      []string
+	client    *http.Client
+}
+
+type deviceCreateRequest struct {
+	Hostname        string   `json:"hostname"`
+	Metro           string   `json:"metro"`
+	Plan            string   `json:"plan"`
+	OperatingSystem string   `json:"operating_system"`
+	Userdata        string   `json:"userdata"`
+	Tags            []string `json:"tags"`
+}
+
+type device struct {
+	ID       string   `json:"id"`
+	Hostname string   `json:"hostname"`
+	Tags     []string `json:"tags"`
+}
+
+type deviceListResponse struct {
+	Devices []device `json:"devices"`
+}
+
+func New(_ context.Context, c *cli.Command, cfg *config.Config) (types.Provider, error) {
+	apiToken := c.String("equinixmetal-api-token")
+	if apiToken == "" {
+		return nil, fmt.Errorf("equinixmetal-api-token must be set")
+	}
+	projectID := c.String("equinixmetal-project-id")
+	if projectID == "" {
+		return nil, fmt.Errorf("equinixmetal-project-id must be set")
+	}
+
+	return &provider{
+		name:      "equinixmetal",
+		config:    cfg,
+		apiToken:  apiToken,
+		projectID: projectID,
+		metro:     c.String("equinixmetal-metro"),
+		plan:      c.String("equinixmetal-plan"),
+		os:        c.String("equinixmetal-os"),
+		tags:      c.StringSlice("equinixmetal-tags"),
+		client:    &http.Client{},
+	}, nil
+}
+
+func (p *provider) do(ctx context.Context, method, path string, body any) ([]byte, int, error) {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, err
+		}
+		reqBody = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, apiBase+path, reqBody)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("X-Auth-Token", p.apiToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return data, resp.StatusCode, nil
+}
+
+func (p *provider) DeployAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	userData, err := cloudinit.RenderUserDataTemplate(p.config, agent, cloudinit.RenderOption{})
+	if err != nil {
+		return fmt.Errorf("%s: cloudinit.RenderUserDataTemplate: %w", p.name, err)
+	}
+
+	tags := append([]string{p.config.PoolID}, p.tags...)
+
+	req := deviceCreateRequest{
+		Hostname:        agent.Name,
+		Metro:           p.metro,
+		Plan:            p.plan,
+		OperatingSystem: p.os,
+		Userdata:        userData,
+		Tags:            tags,
+	}
+
+	data, status, err := p.do(ctx, http.MethodPost, "/projects/"+p.projectID+"/devices", req)
+	if err != nil {
+		return fmt.Errorf("%s: create device: %w", p.name, err)
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("%s: create device: unexpected status %d: %s", p.name, status, string(data))
+	}
+
+	log.Debug().Str("agent", agent.Name).Msgf("%s: device created", p.name)
+	return nil
+}
+
+func (p *provider) RemoveAgent(ctx context.Context, agent *woodpecker.Agent) error {
+	id, err := p.findDeviceID(ctx, agent.Name)
+	if err != nil {
+		return fmt.Errorf("%s: findDeviceID: %w", p.name, err)
+	}
+	if id == "" {
+		log.Debug().Str("agent", agent.Name).Msgf("%s: device not found, skipping removal", p.name)
+		return nil
+	}
+
+	data, status, err := p.do(ctx, http.MethodDelete, "/devices/"+id, nil)
+	if err != nil {
+		return fmt.Errorf("%s: delete device: %w", p.name, err)
+	}
+	if status < 200 || status >= 300 {
+		return fmt.Errorf("%s: delete device: unexpected status %d: %s", p.name, status, string(data))
+	}
+
+	log.Debug().Str("agent", agent.Name).Msgf("%s: device removed", p.name)
+	return nil
+}
+
+func (p *provider) ListDeployedAgentNames(ctx context.Context) ([]string, error) {
+	data, status, err := p.do(ctx, http.MethodGet, "/projects/"+p.projectID+"/devices?per_page=100", nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: list devices: %w", p.name, err)
+	}
+	if status < 200 || status >= 300 {
+		return nil, fmt.Errorf("%s: list devices: unexpected status %d: %s", p.name, status, string(data))
+	}
+
+	var resp deviceListResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, fmt.Errorf("%s: decode devices: %w", p.name, err)
+	}
+
+	var names []string
+	for _, d := range resp.Devices {
+		for _, tag := range d.Tags {
+			if tag == p.config.PoolID {
+				names = append(names, d.Hostname)
+				break
+			}
+		}
+	}
+	return names, nil
+}
+
+func (p *provider) findDeviceID(ctx context.Context, hostname string) (string, error) {
+	data, status, err := p.do(ctx, http.MethodGet, "/projects/"+p.projectID+"/devices?per_page=100", nil)
+	if err != nil {
+		return "", fmt.Errorf("%s: list devices: %w", p.name, err)
+	}
+	if status < 200 || status >= 300 {
+		return "", fmt.Errorf("%s: list devices: unexpected status %d: %s", p.name, status, string(data))
+	}
+
+	var resp deviceListResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", fmt.Errorf("%s: decode devices: %w", p.name, err)
+	}
+
+	for _, d := range resp.Devices {
+		if d.Hostname == hostname {
+			return d.ID, nil
+		}
+	}
+	return "", nil
+}


### PR DESCRIPTION
Closes #104

## Summary

Adds an Equinix Metal provider that implements the full Provider interface:

- DeployAgent — creates a device via POST /projects/{id}/devices with cloud-init userdata and pool-ID tag
- RemoveAgent — locates the device by hostname and deletes it via DELETE /devices/{id}  
- ListDeployedAgentNames — lists all project devices and returns hostnames tagged with the pool ID

## Implementation notes

Uses 
et/http directly against the Equinix Metal REST API (https://api.equinix.com/metal/v1) — no external SDK dependency, so go.mod is unchanged.

## Configuration flags

| Flag | Env | Default | Description |
|---|---|---|---|
| --equinixmetal-api-token | WOODPECKER_EQUINIXMETAL_API_TOKEN | — | API token (required) |
| --equinixmetal-project-id | WOODPECKER_EQUINIXMETAL_PROJECT_ID | — | Project ID (required) |
| --equinixmetal-metro | WOODPECKER_EQUINIXMETAL_METRO | da | Metro code |
| --equinixmetal-plan | WOODPECKER_EQUINIXMETAL_PLAN | c3.small.x86 | Device plan |
| --equinixmetal-os | WOODPECKER_EQUINIXMETAL_OS | ubuntu_22_04 | OS slug |
| --equinixmetal-tags | WOODPECKER_EQUINIXMETAL_TAGS | — | Additional tags |