### PR TITLE
fix(config): address overly-broad `.gitignore` entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.dylib
 vendor/
 __debug_bin
-woodpecker-autoscaler
+/dist/woodpecker-autoscaler
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.dylib
 vendor/
 __debug_bin
-/dist/woodpecker-autoscaler
+/woodpecker-autoscaler
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
Addresses [this](https://github.com/woodpecker-ci/autoscaler/issues/648) unintentional misconfiguration of `.gitignore`.