### PR TITLE
Trim leading whitespace from rendered cloud-init user data

### DIFF
--- a/engine/inits/cloudinit/cloudinit.go
+++ b/engine/inits/cloudinit/cloudinit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"go.woodpecker-ci.org/autoscaler/config"
 	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
@@ -61,7 +62,10 @@ func RenderUserDataTemplate(config *config.Config, agent *woodpecker.Agent, r Re
 		return "", err
 	}
 
-	return userData.String(), nil
+	// cloud-init only recognizes user data if the header (e.g. #cloud-config)
+	// is on the very first line. Some datasources tolerate leading whitespace,
+	// stricter ones such as NoCloud silently ignore the whole payload.
+	return strings.TrimLeftFunc(userData.String(), unicode.IsSpace), nil
 }
 
 func genExtraAgentLabels(conf map[string]string) string {
@@ -73,8 +77,7 @@ func genExtraAgentLabels(conf map[string]string) string {
 }
 
 // editorconfig-checker-disable
-var CloudInitUserDataUbuntuDefault = `
-#cloud-config
+var CloudInitUserDataUbuntuDefault = `#cloud-config
 
 package_reboot_if_required: false
 package_update: true

--- a/engine/inits/cloudinit/cloudinit.go
+++ b/engine/inits/cloudinit/cloudinit.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
-	"unicode"
 
 	"go.woodpecker-ci.org/autoscaler/config"
 	"go.woodpecker-ci.org/woodpecker/v3/woodpecker-go/woodpecker"
@@ -65,7 +64,7 @@ func RenderUserDataTemplate(config *config.Config, agent *woodpecker.Agent, r Re
 	// cloud-init only recognizes user data if the header (e.g. #cloud-config)
 	// is on the very first line. Some datasources tolerate leading whitespace,
 	// stricter ones such as NoCloud silently ignore the whole payload.
-	return strings.TrimLeftFunc(userData.String(), unicode.IsSpace), nil
+	return strings.TrimSpace(userData.String()), nil
 }
 
 func genExtraAgentLabels(conf map[string]string) string {

--- a/engine/inits/cloudinit/cloudinit_test.go
+++ b/engine/inits/cloudinit/cloudinit_test.go
@@ -62,7 +62,7 @@ func TestRenderUserDataTemplate_DefaultStartsWithCloudConfigHeader(t *testing.T)
 	assert.True(t, strings.HasPrefix(userData, "#cloud-config\n"), "user data must start with the cloud-config header")
 }
 
-func TestRenderUserDataTemplate_TrimsLeadingWhitespace(t *testing.T) {
+func TestRenderUserDataTemplate_TrimsWhitespace(t *testing.T) {
 	config := &config.Config{
 		UserData: "\n\n  \t#cloud-config\nimage: {{ .Image }}\n",
 		Image:    "test-image",
@@ -71,7 +71,7 @@ func TestRenderUserDataTemplate_TrimsLeadingWhitespace(t *testing.T) {
 	userData, err := cloudinit.RenderUserDataTemplate(config, &woodpecker.Agent{}, cloudinit.RenderOption{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "#cloud-config\nimage: test-image\n", userData)
+	assert.Equal(t, "#cloud-config\nimage: test-image", userData)
 }
 
 func TestRenderUserDataTemplate_Error(t *testing.T) {
@@ -145,7 +145,6 @@ runcmd:
   - sh -xc "cd /root; docker compose up -d"
   - echo exec after docker up
 
-final_message: "The system is finally up, after $UPTIME seconds"
-`, conf)
+final_message: "The system is finally up, after $UPTIME seconds"`, conf)
 	// editorconfig-checker-enable
 }

--- a/engine/inits/cloudinit/cloudinit_test.go
+++ b/engine/inits/cloudinit/cloudinit_test.go
@@ -1,6 +1,7 @@
 package cloudinit_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,25 @@ func TestRenderUserDataTemplate_Secure(t *testing.T) {
 	assert.Contains(t, userData, "WOODPECKER_GRPC_SECURE=true")
 }
 
+func TestRenderUserDataTemplate_DefaultStartsWithCloudConfigHeader(t *testing.T) {
+	userData, err := cloudinit.RenderUserDataTemplate(&config.Config{}, &woodpecker.Agent{}, cloudinit.RenderOption{})
+
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(userData, "#cloud-config\n"), "user data must start with the cloud-config header")
+}
+
+func TestRenderUserDataTemplate_TrimsLeadingWhitespace(t *testing.T) {
+	config := &config.Config{
+		UserData: "\n\n  \t#cloud-config\nimage: {{ .Image }}\n",
+		Image:    "test-image",
+	}
+
+	userData, err := cloudinit.RenderUserDataTemplate(config, &woodpecker.Agent{}, cloudinit.RenderOption{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "#cloud-config\nimage: test-image\n", userData)
+}
+
 func TestRenderUserDataTemplate_Error(t *testing.T) {
 	config := &config.Config{
 		UserData: "{{.Missing}}",
@@ -77,8 +97,7 @@ func TestRenderUserDataTemplate_CustomCommands(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	// editorconfig-checker-disable
-	assert.EqualValues(t, `
-#cloud-config
+	assert.EqualValues(t, `#cloud-config
 
 package_reboot_if_required: false
 package_update: true


### PR DESCRIPTION
Closes #655

The bundled `CloudInitUserDataUbuntuDefault` template started with a newline, so the rendered user data was `"\n#cloud-config\n..."`. cloud-init only recognizes the payload when the header is on the very first line; some datasources tolerate leading whitespace, but stricter ones such as NoCloud (Proxmox `cidata` ISO) silently ignore the whole payload and the agent never gets provisioned.

Changes:

- remove the leading newline from the default template
- `RenderUserDataTemplate` now trims leading whitespace from the rendered output, so user-supplied templates that start with a blank line (common with raw string literals or `_FILE` env vars) work as well
- tests: assert the default output starts with `#cloud-config`, cover the trimming, and update the golden output in `TestRenderUserDataTemplate_CustomCommands`
