### PR TITLE
Fix RandomString returning identical values within one clock tick

### DIFF
--- a/utils/random.go
+++ b/utils/random.go
@@ -1,18 +1,17 @@
 package utils
 
-import (
-	"math/rand"
-	"time"
-)
+import "math/rand/v2"
 
-// RandomString generates a random string of length n using alphanumeric characters.
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// RandomString returns a random string of length n. It uses the shared
+// math/rand/v2 generator: seeding a fresh source per call with the wall clock
+// produces identical strings for calls within one clock tick, which happens
+// routinely on platforms with coarse clocks such as Windows.
 func RandomString(n int) string {
-	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rng.Intn(len(letterRunes))]
+		b[i] = letterRunes[rand.IntN(len(letterRunes))]
 	}
 	return string(b)
 }

--- a/utils/random_test.go
+++ b/utils/random_test.go
@@ -40,3 +40,17 @@ func TestRandomString(t *testing.T) {
 		})
 	}
 }
+
+// Rapid successive calls must not repeat: a generator re-seeded from the wall
+// clock on every call collapses to identical output within one clock tick on
+// coarse-clock platforms, producing duplicate agent names.
+func TestRandomStringRapidCallsAreUnique(t *testing.T) {
+	const calls = 1000
+
+	seen := make(map[string]struct{}, calls)
+	for range calls {
+		seen[utils.RandomString(10)] = struct{}{}
+	}
+
+	assert.Len(t, seen, calls)
+}


### PR DESCRIPTION
RandomString created a fresh math/rand source seeded with time.Now().UnixNano() on every call. Two calls within the same wall clock tick get the same seed and return the identical string. On Linux the clock ticks in nanoseconds so this almost never happens, but on platforms with a coarse wall clock (Windows) it happens almost always: measured 968 of 1000 back-to-back call pairs returning the same value.

Consequence in the engine: when one reconcile cycle deploys several agents in a tight loop, they can all get the same name (engine/agents.go builds names from RandomString). Duplicate names later break removal, e.g. the providers error with "found multiple droplets/instances named X". It is also what makes the e2e suite on the update-architecutre branch (#581) fail consistently on Windows while Linux CI stays green, see the discussion in https://github.com/woodpecker-ci/autoscaler/pull/661#issuecomment-5354898142.

Fix: use the shared math/rand/v2 generator, which is seeded once and goroutine safe, instead of re-seeding per call. After the fix: 0 of 1000 collisions, and the e2e suite on the refactor branch passes 10 of 10 runs on Windows, including with -race.

Includes a regression test asserting 1000 rapid calls yield 1000 distinct strings.